### PR TITLE
Redesign CLI surface

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,12 +6,6 @@ const DEFAULT_IMAGE: &'static str = "docker.io/bitnami/git:latest";
 #[command(about = "Prunes all rooz resources")]
 pub struct PruneParams {}
 
-#[derive(Parser, Debug)]
-#[command(about = "Lists workspaces", alias="ls")]
-pub struct ListParams {
-
-}
-
 #[derive(Subcommand, Debug)]
 pub enum SystemCommands {
     Prune(PruneParams),
@@ -22,14 +16,6 @@ pub enum SystemCommands {
 pub struct System {
     #[command(subcommand)]
     pub command: SystemCommands,
-}
-
-#[derive(Subcommand, Debug)]
-pub enum Commands {
-    New(NewParams),
-    Enter (EnterParams),
-    List(ListParams),
-    System(System),
 }
 
 #[derive(Parser, Debug)]
@@ -57,6 +43,7 @@ pub struct WorkParams {
 }
 
 #[derive(Parser, Debug)]
+#[command(about = "Creates a new workspace (container + volumes)")]
 pub struct NewParams {
     pub name: String,
     #[command(flatten)]
@@ -66,6 +53,7 @@ pub struct NewParams {
 }
 
 #[derive(Parser, Debug)]
+#[command(about = "Opens an interactive shell to a workspace's container")]
 pub struct EnterParams {
     pub name: String,
     #[arg(short, long, default_value = "bash", env = "ROOZ_SHELL")]
@@ -74,6 +62,26 @@ pub struct EnterParams {
     pub work_dir: Option<String>,
 }
 
+#[derive(Parser, Debug)]
+#[command(about = "Lists workspaces", alias = "ls")]
+pub struct ListParams {}
+
+#[derive(Parser, Debug)]
+#[command(about = "Removes a workspace", alias = "rm")]
+pub struct RemoveParams {
+    pub name: String,
+    #[arg(short, long)]
+    pub force: bool
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    New(NewParams),
+    Enter(EnterParams),
+    List(ListParams),
+    Remove(RemoveParams),
+    System(System),
+}
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,17 +4,17 @@ const DEFAULT_IMAGE: &'static str = "docker.io/bitnami/git:latest";
 
 #[derive(Parser, Debug)]
 #[command(about = "Prunes all rooz resources")]
-pub struct Prune {}
+pub struct PruneParams {}
 
 #[derive(Parser, Debug)]
 #[command(about = "Lists workspaces", alias="ls")]
-pub struct List {
+pub struct ListParams {
 
 }
 
 #[derive(Subcommand, Debug)]
 pub enum SystemCommands {
-    Prune(Prune),
+    Prune(PruneParams),
 }
 
 #[derive(Parser, Debug)]
@@ -26,16 +26,15 @@ pub struct System {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
-    Work { name: Option<String> },
-    List(List),
+    New(NewParams),
+    Enter (EnterParams),
+    List(ListParams),
     System(System),
 }
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
-pub struct Cli {
-    #[command(subcommand)]
-    pub command: Option<Commands>,
+pub struct WorkParams {
     pub git_ssh_url: Option<String>,
     #[arg(short, long, default_value = DEFAULT_IMAGE, env = "ROOZ_IMAGE")]
     pub image: String,
@@ -53,11 +52,32 @@ pub struct Cli {
         help = "Enables defining global shared caches"
     )]
     pub caches: Option<Vec<String>>,
-    #[arg(
-        long,
-        help = "Prunes containers and volumes scoped to the provided git repository"
-    )]
-    pub prune: bool,
     #[arg(short, long)]
     pub privileged: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct NewParams {
+    #[command(flatten)]
+    pub work: WorkParams,
+    pub name: String,
+    #[arg(short, long)]
+    pub force: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct EnterParams {
+    pub name: String,
+    #[arg(short, long, default_value = "bash", env = "ROOZ_SHELL")]
+    pub shell: String,
+    #[arg(short, long)]
+    pub work_dir: Option<String>,
+}
+
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,7 +71,7 @@ pub struct ListParams {}
 pub struct RemoveParams {
     pub name: String,
     #[arg(short, long)]
-    pub force: bool
+    pub force: bool,
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,9 +58,9 @@ pub struct WorkParams {
 
 #[derive(Parser, Debug)]
 pub struct NewParams {
+    pub name: String,
     #[command(flatten)]
     pub work: WorkParams,
-    pub name: String,
     #[arg(short, long)]
     pub force: bool,
 }

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -23,7 +23,7 @@ pub async fn list(docker: &Docker) -> Result<(), Box<dyn std::error::Error + 'st
         {
             let state_icon = match state.as_str() {
                 "running" => "✱",
-                _ => " "
+                _ => " ",
             };
             println!("{} {}", labels[labels::GROUP_KEY], state_icon);
         }

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -1,25 +1,32 @@
-use std::collections::HashMap;
 use crate::labels;
+use std::collections::HashMap;
 
-use bollard::{Docker, service::{ContainerSummary}, container::ListContainersOptions};
+use bollard::{container::ListContainersOptions, service::ContainerSummary, Docker};
 
-pub async fn list(
-    docker: &Docker) -> Result<(), Box<dyn std::error::Error + 'static>> {
-        let is_workspace = labels::is_workspace();
-        let list_options = ListContainersOptions {
-            filters: HashMap::from([("label", vec![is_workspace.as_ref()])]),
-            all: true,
-            ..Default::default()
-        };
+pub async fn list(docker: &Docker) -> Result<(), Box<dyn std::error::Error + 'static>> {
+    let is_workspace = labels::is_workspace();
+    let list_options = ListContainersOptions {
+        filters: HashMap::from([("label", vec![is_workspace.as_ref()])]),
+        all: true,
+        ..Default::default()
+    };
 
-        let container_summary = docker.list_containers(Some(list_options)).await?;
-        println!("WORKSPACE");
-        
-            for c in container_summary {
-                
-                if let ContainerSummary {labels: Some(labels), ..} = c {
-                    println!("{}", labels[labels::GROUP_KEY]);
-                }
-            }
-        Ok(())
+    let container_summary = docker.list_containers(Some(list_options)).await?;
+    println!("WORKSPACE");
+
+    for c in container_summary {
+        if let ContainerSummary {
+            labels: Some(labels),
+            state: Some(state),
+            ..
+        } = c
+        {
+            let state_icon = match state.as_str() {
+                "running" => "✱",
+                _ => " "
+            };
+            println!("{} {}", labels[labels::GROUP_KEY], state_icon);
+        }
+    }
+    Ok(())
 }

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -1,20 +1,25 @@
 use std::collections::HashMap;
 use crate::labels;
 
-use bollard::{Docker, volume::ListVolumesOptions, service::VolumeListResponse};
+use bollard::{Docker, service::{ContainerSummary}, container::ListContainersOptions};
 
 pub async fn list(
     docker: &Docker) -> Result<(), Box<dyn std::error::Error + 'static>> {
         let is_workspace = labels::is_workspace();
-        let list_options = ListVolumesOptions {
+        let list_options = ListContainersOptions {
             filters: HashMap::from([("label", vec![is_workspace.as_ref()])]),
+            all: true,
+            ..Default::default()
         };
-        let VolumeListResponse{ volumes,..} = docker.list_volumes(Some(list_options)).await?;
+
+        let container_summary = docker.list_containers(Some(list_options)).await?;
         println!("WORKSPACE");
-        if let Some(volumes) = volumes {
-            for v in volumes {
-                println!("{}", v.labels[labels::GROUP_KEY]);
+        
+            for c in container_summary {
+                
+                if let ContainerSummary {labels: Some(labels), ..} = c {
+                    println!("{}", labels[labels::GROUP_KEY]);
+                }
             }
-        };
         Ok(())
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,2 +1,2 @@
-pub mod prune;
 pub mod list;
+pub mod prune;

--- a/src/cmd/prune.rs
+++ b/src/cmd/prune.rs
@@ -12,7 +12,7 @@ use crate::{container, labels, ssh};
 async fn prune(
     docker: &Docker,
     filters: HashMap<&str, Vec<&str>>,
-    force: bool
+    force: bool,
 ) -> Result<(), Box<dyn std::error::Error + 'static>> {
     let ls_container_options = ListContainersOptions {
         all: true,
@@ -56,7 +56,7 @@ async fn prune(
 pub async fn prune_workspace(
     docker: &Docker,
     workspace_key: &str,
-    force: bool
+    force: bool,
 ) -> Result<(), Box<dyn std::error::Error + 'static>> {
     let group_key_filter = format!("{}={}", labels::GROUP_KEY, &workspace_key);
     let filters = HashMap::from([

--- a/src/cmd/prune.rs
+++ b/src/cmd/prune.rs
@@ -12,6 +12,7 @@ use crate::{container, labels, ssh};
 async fn prune(
     docker: &Docker,
     filters: HashMap<&str, Vec<&str>>,
+    force: bool
 ) -> Result<(), Box<dyn std::error::Error + 'static>> {
     let ls_container_options = ListContainersOptions {
         all: true,
@@ -21,7 +22,7 @@ async fn prune(
     for cs in docker.list_containers(Some(ls_container_options)).await? {
         if let ContainerSummary { id: Some(id), .. } = cs {
             log::debug!("Force remove container: {}", &id);
-            container::force_remove(&docker, &id).await?
+            container::remove(&docker, &id, force).await?
         }
     }
 
@@ -32,7 +33,7 @@ async fn prune(
 
     if let Some(volumes) = docker.list_volumes(Some(ls_vol_options)).await?.volumes {
         let rm_vol_options = RemoveVolumeOptions {
-            force: true,
+            force,
             ..Default::default()
         };
 
@@ -55,6 +56,7 @@ async fn prune(
 pub async fn prune_workspace(
     docker: &Docker,
     workspace_key: &str,
+    force: bool
 ) -> Result<(), Box<dyn std::error::Error + 'static>> {
     let group_key_filter = format!("{}={}", labels::GROUP_KEY, &workspace_key);
     let filters = HashMap::from([
@@ -62,11 +64,11 @@ pub async fn prune_workspace(
         ("label", vec![&group_key_filter]),
     ]);
 
-    prune(docker, filters).await
+    prune(docker, filters, force).await
 }
 
 pub async fn prune_system(docker: &Docker) -> Result<(), Box<dyn std::error::Error + 'static>> {
     let filters = HashMap::from([("label", vec![labels::ROOZ])]);
 
-    prune(docker, filters).await
+    prune(docker, filters, true).await
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -166,7 +166,7 @@ pub async fn exec_output(
 pub async fn remove(
     docker: &Docker,
     container_id: &str,
-    force: bool
+    force: bool,
 ) -> Result<(), Box<dyn std::error::Error + 'static>> {
     Ok(docker
         .remove_container(

--- a/src/container.rs
+++ b/src/container.rs
@@ -20,7 +20,10 @@ use futures::{Stream, StreamExt};
 use termion::{async_stdin, raw::IntoRawMode, terminal_size};
 use tokio::{io::AsyncWriteExt, spawn, time::sleep};
 
-use crate::{types::{ContainerResult, RunSpec}, labels};
+use crate::{
+    labels,
+    types::{ContainerResult, RunSpec},
+};
 
 async fn start_tty(
     docker: &Docker,
@@ -160,15 +163,16 @@ pub async fn exec_output(
     }
 }
 
-pub async fn force_remove(
+pub async fn remove(
     docker: &Docker,
     container_id: &str,
+    force: bool
 ) -> Result<(), Box<dyn std::error::Error + 'static>> {
     Ok(docker
         .remove_container(
             &container_id,
             Some(RemoveContainerOptions {
-                force: true,
+                force,
                 ..Default::default()
             }),
         )
@@ -231,12 +235,10 @@ pub async fn create<'a>(
                 tty: Some(true),
                 open_stdin: Some(true),
                 host_config: Some(host_config),
-                labels: Some(HashMap::from(
-                    [
-                      (labels::ROOZ, "true"),
-                      (labels::GROUP_KEY, &spec.container_name)
-                    ]
-                )),
+                labels: Some(HashMap::from([
+                    (labels::ROOZ, "true"),
+                    (labels::GROUP_KEY, &spec.container_name),
+                ])),
                 ..Default::default()
             };
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -20,7 +20,7 @@ use futures::{Stream, StreamExt};
 use termion::{async_stdin, raw::IntoRawMode, terminal_size};
 use tokio::{io::AsyncWriteExt, spawn, time::sleep};
 
-use crate::types::{ContainerResult, RunSpec};
+use crate::{types::{ContainerResult, RunSpec}, labels};
 
 async fn start_tty(
     docker: &Docker,
@@ -231,7 +231,12 @@ pub async fn create<'a>(
                 tty: Some(true),
                 open_stdin: Some(true),
                 host_config: Some(host_config),
-                labels: Some(HashMap::from([("dev.rooz", "true")])),
+                labels: Some(HashMap::from(
+                    [
+                      (labels::ROOZ, "true"),
+                      (labels::GROUP_KEY, &spec.container_name)
+                    ]
+                )),
                 ..Default::default()
             };
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -130,7 +130,7 @@ pub async fn clone_repo(
 
         log::debug!("Repo config result: {}", &rooz_cfg);
 
-        container::force_remove(docker, &container_id).await?;
+        container::remove(docker, &container_id, true).await?;
 
         match RoozCfg::deserialize(toml::de::Deserializer::new(&rooz_cfg)).ok() {
             Some(cfg) => Ok((Some(cfg), Some(url))),

--- a/src/git.rs
+++ b/src/git.rs
@@ -96,10 +96,11 @@ pub async fn clone_repo(
             mounts: Some(vec![git_vol_mount.clone(), ssh::mount("/tmp/.ssh")]),
             entrypoint: Some(vec!["cat"]),
             privileged: false,
+            force_recreate: false,
         };
 
-        let container_result = container::run(&docker, run_spec).await?;
-
+        let container_result = container::create(&docker, run_spec).await?;
+        container::start(docker, container_result.id()).await?;
         let container_id = container_result.id();
 
         if let ContainerResult::Created { .. } = container_result {

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -7,7 +7,7 @@ pub fn filter(key: &str, value: &str) -> String {
 }
 
 pub fn is_workspace() -> String {
-    filter(ROLE, "git")
+    filter(ROOZ, "true")
 }
 
 pub fn belongs_to(workspace_key: &str) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,19 +11,20 @@ mod volume;
 
 use std::process;
 
-use crate::cli::{Cli, Commands};
+use crate::cli::{Cli, Commands, ListParams};
 use crate::id::to_safe_id;
 use crate::types::{
     RoozCfg, RoozVolume, RoozVolumeRole, RoozVolumeSharing, RunSpec, VolumeResult, WorkSpec,
 };
 use bollard::Docker;
+use bollard::Container::{ListContainerOptions};
 use clap::Parser;
-use cli::{Prune, System};
+use cli::{EnterParams, PruneParams, System};
 
 async fn work<'a>(
     docker: &Docker,
     spec: WorkSpec<'a>,
-) -> Result<(), Box<dyn std::error::Error + 'static>> {
+) -> Result<String, Box<dyn std::error::Error + 'static>> {
     let home_dir = format!("/home/{}", &spec.user);
     let work_dir = format!("{}/work", &home_dir);
 
@@ -80,23 +81,33 @@ async fn work<'a>(
         mounts: Some(mounts),
         entrypoint: Some(vec!["cat"]),
         privileged: spec.privileged,
+        force_recreate: spec.force_recreate,
     };
 
-    let r = container::run(&docker, run_spec).await?;
+    let r = container::create(&docker, run_spec).await?;
 
-    let work_id = &r.id();
+    let work_id = r.id();
 
+    Ok(work_id.to_string())
+}
+
+pub async fn enter(
+    docker: &Docker,
+    container_id: &str,
+    working_dir: Option<&str>,
+    shell: &str,
+) -> Result<(), Box<dyn std::error::Error + 'static>> {
+    container::start(&docker, container_id).await?;
     container::exec_tty(
         "work",
         &docker,
-        &work_id,
+        &container_id,
         true,
-        Some(&spec.container_working_dir),
+        working_dir,
         None,
-        Some(vec![&spec.shell]),
+        Some(vec![shell]),
     )
     .await?;
-    container::force_remove(&docker, &work_id).await?;
     Ok(())
 }
 
@@ -114,143 +125,287 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     match args {
         Cli {
             command:
-                Some(cli::Commands::System(System {
-                    command: cli::SystemCommands::Prune(Prune {}),
-                })),
+                cli::Commands::System(System {
+                    command: cli::SystemCommands::Prune(PruneParams {}),
+                }),
             ..
         } => {
             cmd::prune::prune_system(&docker).await?;
         }
+
+        // Cli {
+        //     git_ssh_url,
+        //     image,
+        //     pull_image,
+        //     shell,
+        //     user,
+        //     //work_dir,
+        //     prune,
+        //     privileged,
+        //     caches,
+        //     command,
+        // } => {
+        //     let ephemeral = false; // ephemeral containers won't be supported at the moment
+
+        //     let workspace_key = match &git_ssh_url {
+        //         Some(url) => to_safe_id(&url)?,
+        //         None => "rooz-generic".to_string(),
+        //     };
+
+        //     if prune {
+        //         cmd::prune::prune_workspace(&docker, &workspace_key).await?;
+        //         process::exit(0);
+        //     }
+
+        //     let orig_shell = shell;
+        //     let orig_user = user;
+        //     let orig_uid = "1000".to_string();
+        //     let orig_image = image;
+
+        //     let orig_image_id = image::ensure_image(&docker, &orig_image, pull_image).await?;
+
+        //     let ssh_key_vol_result = volume::ensure_volume(
+        //         &docker,
+        //         ssh::ROOZ_SSH_KEY_VOLUME_NAME.into(),
+        //         "ssh-key",
+        //         Some("ssh-key".into()),
+        //     )
+        //     .await;
+
+        //     if let VolumeResult::Created { .. } = ssh_key_vol_result {
+        //         ssh::init_ssh_key(&docker, &orig_image_id, &orig_uid).await?;
+        //     };
+
+        //     let home_dir = format!("/home/{}", &orig_user);
+        //     let work_dir = format!("{}/work", &home_dir);
+
+        //     let work_spec = WorkSpec {
+        //         image: &orig_image,
+        //         image_id: &orig_image_id,
+        //         shell: &orig_shell,
+        //         uid: &orig_uid,
+        //         user: &orig_user,
+        //         container_working_dir: &work_dir,
+        //         container_name: &name,
+        //         is_ephemeral: ephemeral,
+        //         git_vol_mount: None,
+        //         caches: caches.clone(),
+        //         privileged,
+        //         force_recreate: force,
+        //     };
+
+        //     match git::clone_repo(
+        //         &docker,
+        //         &orig_image,
+        //         &orig_image_id,
+        //         &orig_uid,
+        //         git_ssh_url.clone(),
+        //     )
+        //     .await?
+        //     {
+        //         (
+        //             Some(RoozCfg {
+        //                 image: Some(img),
+        //                 shell,
+        //                 caches: repo_caches,
+        //                 ..
+        //             }),
+        //             Some(url),
+        //         ) => {
+        //             log::debug!("Image config read from .rooz.toml in the cloned repo");
+        //             let image_id = image::ensure_image(&docker, &img, pull_image).await?;
+        //             let clone_dir = git::get_clone_dir(&work_dir, Some(url.clone()));
+        //             let git_vol_mount = git::git_volume(&docker, &url, &clone_dir).await?;
+        //             let sh = shell.or(Some(orig_shell.to_string())).unwrap();
+        //             let mut all_caches = vec![];
+        //             if let Some(caches) = caches {
+        //                 all_caches.extend(caches);
+        //             }
+        //             if let Some(caches) = repo_caches {
+        //                 all_caches.extend(caches);
+        //             };
+
+        //             all_caches.dedup();
+
+        //             work(
+        //                 &docker,
+        //                 WorkSpec {
+        //                     image: &img,
+        //                     image_id: &image_id,
+        //                     shell: &sh,
+        //                     container_working_dir: &clone_dir,
+        //                     git_vol_mount: Some(git_vol_mount),
+        //                     caches: Some(all_caches),
+        //                     ..work_spec
+        //                 },
+        //             )
+        //             .await?;
+        //             // enter(&docker, &container_id, &clone_dir, &sh).await?
+        //         }
+        //         (None, Some(url)) => {
+        //             let clone_dir = git::get_clone_dir(&work_dir, git_ssh_url.clone());
+        //             let git_vol_mount = git::git_volume(&docker, &url, &clone_dir).await?;
+        //             work(
+        //                 &docker,
+        //                 WorkSpec {
+        //                     container_working_dir: &clone_dir,
+        //                     git_vol_mount: Some(git_vol_mount),
+        //                     ..work_spec
+        //                 },
+        //             )
+        //             .await?;
+        //             //enter(&docker, &container_id, &clone_dir, &work_spec.shell).await?
+        //         }
+
+        //         _ => {
+        //             let container_id = work(&docker, work_spec).await?;
+        //             //enter(&docker, &container_id, &work_spec.container_working_dir, &work_spec.shell).await?
+        //         }
+        //     };
+        //}
+        //this is a prototype, work it out
         Cli {
-            command: Some(cli::Commands::List(cli::List { })),
+            command:
+                cli::Commands::Enter(EnterParams {
+                    name,
+                    shell,
+                    work_dir,
+                }),
             ..
-        } => {
-            cmd::list::list(&docker).await?;
-        }
+        } => enter(&docker, &name, work_dir.as_deref(), &shell).await?,
         Cli {
-            git_ssh_url,
-            image,
-            pull_image,
-            shell,
-            user,
-            //work_dir,
-            prune,
-            privileged,
-            caches,
-            command,
-        } => {
-            let ephemeral = false; // ephemeral containers won't be supported at the moment
-
-            let workspace_key = match &git_ssh_url {
-                Some(url) => to_safe_id(&url)?,
-                None => "rooz-generic".to_string(),
+            command:
+            cli::Commands::List(ListParams {}),
+            ..
+        } => { 
+            let options = ListContainerOptions {
+                ..Default::default()
             };
-
-            if prune {
-                cmd::prune::prune_workspace(&docker, &workspace_key).await?;
-                process::exit(0);
-            }
-
-            let orig_shell = shell;
-            let orig_user = user;
-            let orig_uid = "1000".to_string();
-            let orig_image = image;
-
-            let orig_image_id = image::ensure_image(&docker, &orig_image, pull_image).await?;
-
-            let ssh_key_vol_result = volume::ensure_volume(
-                &docker,
-                ssh::ROOZ_SSH_KEY_VOLUME_NAME.into(),
-                "ssh-key",
-                Some("ssh-key".into()),
-            )
-            .await;
-
-            if let VolumeResult::Created { .. } = ssh_key_vol_result {
-                ssh::init_ssh_key(&docker, &orig_image_id, &orig_uid).await?;
-            };
-
-            let home_dir = format!("/home/{}", &orig_user);
-            let work_dir = format!("{}/work", &home_dir);
-
-            let work_spec = WorkSpec {
-                image: &orig_image,
-                image_id: &orig_image_id,
-                shell: &orig_shell,
-                uid: &orig_uid,
-                user: &orig_user,
-                container_working_dir: &work_dir,
-                container_name: &workspace_key,
-                is_ephemeral: ephemeral,
-                git_vol_mount: None,
-                caches: caches.clone(),
-                privileged,
-            };
-
-            match git::clone_repo(
-                &docker,
-                &orig_image,
-                &orig_image_id,
-                &orig_uid,
-                git_ssh_url.clone(),
-            )
-            .await?
-            {
-                (
-                    Some(RoozCfg {
-                        image: Some(img),
-                        shell,
-                        caches: repo_caches,
-                        ..
-                    }),
-                    Some(url),
-                ) => {
-                    log::debug!("Image config read from .rooz.toml in the cloned repo");
-                    let image_id = image::ensure_image(&docker, &img, pull_image).await?;
-                    let clone_dir = git::get_clone_dir(&work_dir, Some(url.clone()));
-                    let git_vol_mount = git::git_volume(&docker, &url, &clone_dir).await?;
-                    let sh = shell.or(Some(orig_shell.to_string())).unwrap();
-                    let mut all_caches = vec![];
-                    if let Some(caches) = caches {
-                        all_caches.extend(caches);
-                    }
-                    if let Some(caches) = repo_caches {
-                        all_caches.extend(caches);
-                    };
-
-                    all_caches.dedup();
-
-                    work(
-                        &docker,
-                        WorkSpec {
-                            image: &img,
-                            image_id: &image_id,
-                            shell: &sh,
-                            container_working_dir: &clone_dir,
-                            git_vol_mount: Some(git_vol_mount),
-                            caches: Some(all_caches),
-                            ..work_spec
-                        },
-                    )
-                    .await?
-                }
-                (None, Some(url)) => {
-                    let clone_dir = git::get_clone_dir(&work_dir, git_ssh_url.clone());
-                    let git_vol_mount = git::git_volume(&docker, &url, &clone_dir).await?;
-                    work(
-                        &docker,
-                        WorkSpec {
-                            container_working_dir: &clone_dir,
-                            git_vol_mount: Some(git_vol_mount),
-                            ..work_spec
-                        },
-                    )
-                    .await?
-                }
-
-                _ => work(&docker, work_spec).await?,
-            };
+            &docker.list_containers(Some(options)).await?;
         }
+        // Cli {
+        //     git_ssh_url,
+        //     image,
+        //     pull_image,
+        //     shell,
+        //     user,
+        //     //work_dir,
+        //     prune,
+        //     privileged,
+        //     caches,
+        //     command,
+        // } => {
+        //     // let ephemeral = false; // ephemeral containers won't be supported at the moment
+
+        //     // let workspace_key = match &git_ssh_url {
+        //     //     Some(url) => to_safe_id(&url)?,
+        //     //     None => "rooz-generic".to_string(),
+        //     // };
+
+        //     // if prune {
+        //     //     cmd::prune::prune_workspace(&docker, &workspace_key).await?;
+        //     // }
+
+        //     // let orig_shell = shell;
+        //     // let orig_user = user;
+        //     // let orig_uid = "1000".to_string();
+        //     // let orig_image = image;
+
+        //     // let orig_image_id = image::ensure_image(&docker, &orig_image, pull_image).await?;
+
+        //     // let ssh_key_vol_result = volume::ensure_volume(
+        //     //     &docker,
+        //     //     ssh::ROOZ_SSH_KEY_VOLUME_NAME.into(),
+        //     //     "ssh-key",
+        //     //     Some("ssh-key".into()),
+        //     // )
+        //     // .await;
+
+        //     // if let VolumeResult::Created { .. } = ssh_key_vol_result {
+        //     //     ssh::init_ssh_key(&docker, &orig_image_id, &orig_uid).await?;
+        //     // };
+
+        //     // let home_dir = format!("/home/{}", &orig_user);
+        //     // let work_dir = format!("{}/work", &home_dir);
+
+        //     // let work_spec = WorkSpec {
+        //     //     image: &orig_image,
+        //     //     image_id: &orig_image_id,
+        //     //     shell: &orig_shell,
+        //     //     uid: &orig_uid,
+        //     //     user: &orig_user,
+        //     //     container_working_dir: &work_dir,
+        //     //     container_name: &workspace_key,
+        //     //     is_ephemeral: ephemeral,
+        //     //     git_vol_mount: None,
+        //     //     caches: caches.clone(),
+        //     //     privileged,
+        //     // };
+
+        //     // match git::clone_repo(
+        //     //     &docker,
+        //     //     &orig_image,
+        //     //     &orig_image_id,
+        //     //     &orig_uid,
+        //     //     git_ssh_url.clone(),
+        //     // )
+        //     // .await?
+        //     // {
+        //     //     (
+        //     //         Some(RoozCfg {
+        //     //             image: Some(img),
+        //     //             shell,
+        //     //             caches: repo_caches,
+        //     //             ..
+        //     //         }),
+        //     //         Some(url),
+        //     //     ) => {
+        //     //         log::debug!("Image config read from .rooz.toml in the cloned repo");
+        //     //         let image_id = image::ensure_image(&docker, &img, pull_image).await?;
+        //     //         let clone_dir = git::get_clone_dir(&work_dir, Some(url.clone()));
+        //     //         let git_vol_mount = git::git_volume(&docker, &url, &clone_dir).await?;
+        //     //         let sh = shell.or(Some(orig_shell.to_string())).unwrap();
+        //     //         let mut all_caches = vec![];
+        //     //         if let Some(caches) = caches {
+        //     //             all_caches.extend(caches);
+        //     //         }
+        //     //         if let Some(caches) = repo_caches {
+        //     //             all_caches.extend(caches);
+        //     //         };
+
+        //     //         all_caches.dedup();
+
+        //     //         work(
+        //     //             &docker,
+        //     //             WorkSpec {
+        //     //                 image: &img,
+        //     //                 image_id: &image_id,
+        //     //                 shell: &sh,
+        //     //                 container_working_dir: &clone_dir,
+        //     //                 git_vol_mount: Some(git_vol_mount),
+        //     //                 caches: Some(all_caches),
+        //     //                 ..work_spec
+        //     //             },
+        //     //         )
+        //     //         .await?
+        //     //     }
+        //     //     (None, Some(url)) => {
+        //     //         let clone_dir = git::get_clone_dir(&work_dir, git_ssh_url.clone());
+        //     //         let git_vol_mount = git::git_volume(&docker, &url, &clone_dir).await?;
+        //     //         work(
+        //     //             &docker,
+        //     //             WorkSpec {
+        //     //                 container_working_dir: &clone_dir,
+        //     //                 git_vol_mount: Some(git_vol_mount),
+        //     //                 ..work_spec
+        //     //             },
+        //     //         )
+        //     //         .await?
+        //     //     }
+
+        //     //     _ => work(&docker, work_spec).await?,
+        //     // };
+        // }
     };
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,15 +9,13 @@ mod ssh;
 mod types;
 mod volume;
 
-use std::process;
+use crate::cli::{Cli, ListParams, RemoveParams, WorkParams};
 
-use crate::cli::{Cli, Commands, ListParams, WorkParams};
-use crate::id::to_safe_id;
 use crate::types::{
     RoozCfg, RoozVolume, RoozVolumeRole, RoozVolumeSharing, RunSpec, VolumeResult, WorkSpec,
 };
+
 use bollard::Docker;
-use bollard::container::{ListContainersOptions};
 use clap::Parser;
 use cli::{EnterParams, PruneParams, System};
 
@@ -125,44 +123,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     match args {
         Cli {
             command:
-                cli::Commands::System(System {
-                    command: cli::SystemCommands::Prune(PruneParams {}),
+                cli::Commands::New(cli::NewParams {
+                    work:
+                        WorkParams {
+                            git_ssh_url,
+                            image,
+                            pull_image,
+                            shell,
+                            user,
+                            privileged,
+                            caches,
+                        },
+                    name,
+                    force,
                 }),
             ..
         } => {
-            cmd::prune::prune_system(&docker).await?;
-        },
-        Cli {
-            command:
-        cli::Commands::New(cli::NewParams {
-            work:
-                WorkParams {
-                    git_ssh_url,
-                    image,
-                    pull_image,
-                    shell,
-                    user,
-                    //work_dir,
-                    //prune,
-                    privileged,
-                    caches,
-                },
-            name,
-            force,
-        }),..}  => 
-
-        {
             let ephemeral = false; // ephemeral containers won't be supported at the moment
-
-            let workspace_key = match &git_ssh_url {
-                Some(url) => to_safe_id(&url)?,
-                None => "rooz-generic".to_string(),
-            };
-
-            // if prune {
-            //     cmd::prune::prune_workspace(&docker, &workspace_key).await?;
-            //     process::exit(0);
-            // }
 
             let orig_shell = shell;
             let orig_user = user;
@@ -270,7 +247,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
                 }
             };
         }
-        //this is a prototype, work it out
         Cli {
             command:
                 cli::Commands::Enter(EnterParams {
@@ -281,135 +257,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
             ..
         } => enter(&docker, &name, work_dir.as_deref(), &shell).await?,
         Cli {
-            command:
-            cli::Commands::List(ListParams {}),
+            command: cli::Commands::List(ListParams {}),
             ..
-        } => { 
-            cmd::list::list(&docker).await?
+        } => cmd::list::list(&docker).await?,
+        Cli {
+            command: cli::Commands::Remove(RemoveParams { name, force }),
+            ..
+        } => {
+            cmd::prune::prune_workspace(&docker, &name, force).await?;
         }
-        // Cli {
-        //     git_ssh_url,
-        //     image,
-        //     pull_image,
-        //     shell,
-        //     user,
-        //     //work_dir,
-        //     prune,
-        //     privileged,
-        //     caches,
-        //     command,
-        // } => {
-        //     // let ephemeral = false; // ephemeral containers won't be supported at the moment
-
-        //     // let workspace_key = match &git_ssh_url {
-        //     //     Some(url) => to_safe_id(&url)?,
-        //     //     None => "rooz-generic".to_string(),
-        //     // };
-
-        //     // if prune {
-        //     //     cmd::prune::prune_workspace(&docker, &workspace_key).await?;
-        //     // }
-
-        //     // let orig_shell = shell;
-        //     // let orig_user = user;
-        //     // let orig_uid = "1000".to_string();
-        //     // let orig_image = image;
-
-        //     // let orig_image_id = image::ensure_image(&docker, &orig_image, pull_image).await?;
-
-        //     // let ssh_key_vol_result = volume::ensure_volume(
-        //     //     &docker,
-        //     //     ssh::ROOZ_SSH_KEY_VOLUME_NAME.into(),
-        //     //     "ssh-key",
-        //     //     Some("ssh-key".into()),
-        //     // )
-        //     // .await;
-
-        //     // if let VolumeResult::Created { .. } = ssh_key_vol_result {
-        //     //     ssh::init_ssh_key(&docker, &orig_image_id, &orig_uid).await?;
-        //     // };
-
-        //     // let home_dir = format!("/home/{}", &orig_user);
-        //     // let work_dir = format!("{}/work", &home_dir);
-
-        //     // let work_spec = WorkSpec {
-        //     //     image: &orig_image,
-        //     //     image_id: &orig_image_id,
-        //     //     shell: &orig_shell,
-        //     //     uid: &orig_uid,
-        //     //     user: &orig_user,
-        //     //     container_working_dir: &work_dir,
-        //     //     container_name: &workspace_key,
-        //     //     is_ephemeral: ephemeral,
-        //     //     git_vol_mount: None,
-        //     //     caches: caches.clone(),
-        //     //     privileged,
-        //     // };
-
-        //     // match git::clone_repo(
-        //     //     &docker,
-        //     //     &orig_image,
-        //     //     &orig_image_id,
-        //     //     &orig_uid,
-        //     //     git_ssh_url.clone(),
-        //     // )
-        //     // .await?
-        //     // {
-        //     //     (
-        //     //         Some(RoozCfg {
-        //     //             image: Some(img),
-        //     //             shell,
-        //     //             caches: repo_caches,
-        //     //             ..
-        //     //         }),
-        //     //         Some(url),
-        //     //     ) => {
-        //     //         log::debug!("Image config read from .rooz.toml in the cloned repo");
-        //     //         let image_id = image::ensure_image(&docker, &img, pull_image).await?;
-        //     //         let clone_dir = git::get_clone_dir(&work_dir, Some(url.clone()));
-        //     //         let git_vol_mount = git::git_volume(&docker, &url, &clone_dir).await?;
-        //     //         let sh = shell.or(Some(orig_shell.to_string())).unwrap();
-        //     //         let mut all_caches = vec![];
-        //     //         if let Some(caches) = caches {
-        //     //             all_caches.extend(caches);
-        //     //         }
-        //     //         if let Some(caches) = repo_caches {
-        //     //             all_caches.extend(caches);
-        //     //         };
-
-        //     //         all_caches.dedup();
-
-        //     //         work(
-        //     //             &docker,
-        //     //             WorkSpec {
-        //     //                 image: &img,
-        //     //                 image_id: &image_id,
-        //     //                 shell: &sh,
-        //     //                 container_working_dir: &clone_dir,
-        //     //                 git_vol_mount: Some(git_vol_mount),
-        //     //                 caches: Some(all_caches),
-        //     //                 ..work_spec
-        //     //             },
-        //     //         )
-        //     //         .await?
-        //     //     }
-        //     //     (None, Some(url)) => {
-        //     //         let clone_dir = git::get_clone_dir(&work_dir, git_ssh_url.clone());
-        //     //         let git_vol_mount = git::git_volume(&docker, &url, &clone_dir).await?;
-        //     //         work(
-        //     //             &docker,
-        //     //             WorkSpec {
-        //     //                 container_working_dir: &clone_dir,
-        //     //                 git_vol_mount: Some(git_vol_mount),
-        //     //                 ..work_spec
-        //     //             },
-        //     //         )
-        //     //         .await?
-        //     //     }
-
-        //     //     _ => work(&docker, work_spec).await?,
-        //     // };
-        // }
+        Cli {
+            command:
+                cli::Commands::System(System {
+                    command: cli::SystemCommands::Prune(PruneParams {}),
+                }),
+            ..
+        } => {
+            cmd::prune::prune_system(&docker).await?;
+        }
     };
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,13 +11,13 @@ mod volume;
 
 use std::process;
 
-use crate::cli::{Cli, Commands, ListParams};
+use crate::cli::{Cli, Commands, ListParams, WorkParams};
 use crate::id::to_safe_id;
 use crate::types::{
     RoozCfg, RoozVolume, RoozVolumeRole, RoozVolumeSharing, RunSpec, VolumeResult, WorkSpec,
 };
 use bollard::Docker;
-use bollard::Container::{ListContainerOptions};
+use bollard::container::{ListContainersOptions};
 use clap::Parser;
 use cli::{EnterParams, PruneParams, System};
 
@@ -131,138 +131,145 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
             ..
         } => {
             cmd::prune::prune_system(&docker).await?;
+        },
+        Cli {
+            command:
+        cli::Commands::New(cli::NewParams {
+            work:
+                WorkParams {
+                    git_ssh_url,
+                    image,
+                    pull_image,
+                    shell,
+                    user,
+                    //work_dir,
+                    //prune,
+                    privileged,
+                    caches,
+                },
+            name,
+            force,
+        }),..}  => 
+
+        {
+            let ephemeral = false; // ephemeral containers won't be supported at the moment
+
+            let workspace_key = match &git_ssh_url {
+                Some(url) => to_safe_id(&url)?,
+                None => "rooz-generic".to_string(),
+            };
+
+            // if prune {
+            //     cmd::prune::prune_workspace(&docker, &workspace_key).await?;
+            //     process::exit(0);
+            // }
+
+            let orig_shell = shell;
+            let orig_user = user;
+            let orig_uid = "1000".to_string();
+            let orig_image = image;
+
+            let orig_image_id = image::ensure_image(&docker, &orig_image, pull_image).await?;
+
+            let ssh_key_vol_result = volume::ensure_volume(
+                &docker,
+                ssh::ROOZ_SSH_KEY_VOLUME_NAME.into(),
+                "ssh-key",
+                Some("ssh-key".into()),
+            )
+            .await;
+
+            if let VolumeResult::Created { .. } = ssh_key_vol_result {
+                ssh::init_ssh_key(&docker, &orig_image_id, &orig_uid).await?;
+            };
+
+            let home_dir = format!("/home/{}", &orig_user);
+            let work_dir = format!("{}/work", &home_dir);
+
+            let work_spec = WorkSpec {
+                image: &orig_image,
+                image_id: &orig_image_id,
+                shell: &orig_shell,
+                uid: &orig_uid,
+                user: &orig_user,
+                container_working_dir: &work_dir,
+                container_name: &name,
+                is_ephemeral: ephemeral,
+                git_vol_mount: None,
+                caches: caches.clone(),
+                privileged,
+                force_recreate: force,
+            };
+
+            match git::clone_repo(
+                &docker,
+                &orig_image,
+                &orig_image_id,
+                &orig_uid,
+                git_ssh_url.clone(),
+            )
+            .await?
+            {
+                (
+                    Some(RoozCfg {
+                        image: Some(img),
+                        shell,
+                        caches: repo_caches,
+                        ..
+                    }),
+                    Some(url),
+                ) => {
+                    log::debug!("Image config read from .rooz.toml in the cloned repo");
+                    let image_id = image::ensure_image(&docker, &img, pull_image).await?;
+                    let clone_dir = git::get_clone_dir(&work_dir, Some(url.clone()));
+                    let git_vol_mount = git::git_volume(&docker, &url, &clone_dir).await?;
+                    let sh = shell.or(Some(orig_shell.to_string())).unwrap();
+                    let mut all_caches = vec![];
+                    if let Some(caches) = caches {
+                        all_caches.extend(caches);
+                    }
+                    if let Some(caches) = repo_caches {
+                        all_caches.extend(caches);
+                    };
+
+                    all_caches.dedup();
+
+                    work(
+                        &docker,
+                        WorkSpec {
+                            image: &img,
+                            image_id: &image_id,
+                            shell: &sh,
+                            container_working_dir: &clone_dir,
+                            git_vol_mount: Some(git_vol_mount),
+                            caches: Some(all_caches),
+                            ..work_spec
+                        },
+                    )
+                    .await?;
+                    // enter(&docker, &container_id, &clone_dir, &sh).await?
+                }
+                (None, Some(url)) => {
+                    let clone_dir = git::get_clone_dir(&work_dir, git_ssh_url.clone());
+                    let git_vol_mount = git::git_volume(&docker, &url, &clone_dir).await?;
+                    work(
+                        &docker,
+                        WorkSpec {
+                            container_working_dir: &clone_dir,
+                            git_vol_mount: Some(git_vol_mount),
+                            ..work_spec
+                        },
+                    )
+                    .await?;
+                    //enter(&docker, &container_id, &clone_dir, &work_spec.shell).await?
+                }
+
+                _ => {
+                    let container_id = work(&docker, work_spec).await?;
+                    //enter(&docker, &container_id, &work_spec.container_working_dir, &work_spec.shell).await?
+                }
+            };
         }
-
-        // Cli {
-        //     git_ssh_url,
-        //     image,
-        //     pull_image,
-        //     shell,
-        //     user,
-        //     //work_dir,
-        //     prune,
-        //     privileged,
-        //     caches,
-        //     command,
-        // } => {
-        //     let ephemeral = false; // ephemeral containers won't be supported at the moment
-
-        //     let workspace_key = match &git_ssh_url {
-        //         Some(url) => to_safe_id(&url)?,
-        //         None => "rooz-generic".to_string(),
-        //     };
-
-        //     if prune {
-        //         cmd::prune::prune_workspace(&docker, &workspace_key).await?;
-        //         process::exit(0);
-        //     }
-
-        //     let orig_shell = shell;
-        //     let orig_user = user;
-        //     let orig_uid = "1000".to_string();
-        //     let orig_image = image;
-
-        //     let orig_image_id = image::ensure_image(&docker, &orig_image, pull_image).await?;
-
-        //     let ssh_key_vol_result = volume::ensure_volume(
-        //         &docker,
-        //         ssh::ROOZ_SSH_KEY_VOLUME_NAME.into(),
-        //         "ssh-key",
-        //         Some("ssh-key".into()),
-        //     )
-        //     .await;
-
-        //     if let VolumeResult::Created { .. } = ssh_key_vol_result {
-        //         ssh::init_ssh_key(&docker, &orig_image_id, &orig_uid).await?;
-        //     };
-
-        //     let home_dir = format!("/home/{}", &orig_user);
-        //     let work_dir = format!("{}/work", &home_dir);
-
-        //     let work_spec = WorkSpec {
-        //         image: &orig_image,
-        //         image_id: &orig_image_id,
-        //         shell: &orig_shell,
-        //         uid: &orig_uid,
-        //         user: &orig_user,
-        //         container_working_dir: &work_dir,
-        //         container_name: &name,
-        //         is_ephemeral: ephemeral,
-        //         git_vol_mount: None,
-        //         caches: caches.clone(),
-        //         privileged,
-        //         force_recreate: force,
-        //     };
-
-        //     match git::clone_repo(
-        //         &docker,
-        //         &orig_image,
-        //         &orig_image_id,
-        //         &orig_uid,
-        //         git_ssh_url.clone(),
-        //     )
-        //     .await?
-        //     {
-        //         (
-        //             Some(RoozCfg {
-        //                 image: Some(img),
-        //                 shell,
-        //                 caches: repo_caches,
-        //                 ..
-        //             }),
-        //             Some(url),
-        //         ) => {
-        //             log::debug!("Image config read from .rooz.toml in the cloned repo");
-        //             let image_id = image::ensure_image(&docker, &img, pull_image).await?;
-        //             let clone_dir = git::get_clone_dir(&work_dir, Some(url.clone()));
-        //             let git_vol_mount = git::git_volume(&docker, &url, &clone_dir).await?;
-        //             let sh = shell.or(Some(orig_shell.to_string())).unwrap();
-        //             let mut all_caches = vec![];
-        //             if let Some(caches) = caches {
-        //                 all_caches.extend(caches);
-        //             }
-        //             if let Some(caches) = repo_caches {
-        //                 all_caches.extend(caches);
-        //             };
-
-        //             all_caches.dedup();
-
-        //             work(
-        //                 &docker,
-        //                 WorkSpec {
-        //                     image: &img,
-        //                     image_id: &image_id,
-        //                     shell: &sh,
-        //                     container_working_dir: &clone_dir,
-        //                     git_vol_mount: Some(git_vol_mount),
-        //                     caches: Some(all_caches),
-        //                     ..work_spec
-        //                 },
-        //             )
-        //             .await?;
-        //             // enter(&docker, &container_id, &clone_dir, &sh).await?
-        //         }
-        //         (None, Some(url)) => {
-        //             let clone_dir = git::get_clone_dir(&work_dir, git_ssh_url.clone());
-        //             let git_vol_mount = git::git_volume(&docker, &url, &clone_dir).await?;
-        //             work(
-        //                 &docker,
-        //                 WorkSpec {
-        //                     container_working_dir: &clone_dir,
-        //                     git_vol_mount: Some(git_vol_mount),
-        //                     ..work_spec
-        //                 },
-        //             )
-        //             .await?;
-        //             //enter(&docker, &container_id, &clone_dir, &work_spec.shell).await?
-        //         }
-
-        //         _ => {
-        //             let container_id = work(&docker, work_spec).await?;
-        //             //enter(&docker, &container_id, &work_spec.container_working_dir, &work_spec.shell).await?
-        //         }
-        //     };
-        //}
         //this is a prototype, work it out
         Cli {
             command:
@@ -278,10 +285,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
             cli::Commands::List(ListParams {}),
             ..
         } => { 
-            let options = ListContainerOptions {
-                ..Default::default()
-            };
-            &docker.list_containers(Some(options)).await?;
+            cmd::list::list(&docker).await?
         }
         // Cli {
         //     git_ssh_url,

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -40,11 +40,13 @@ chown -R {} /tmp/.ssh
         }]),
         entrypoint: Some(init_entrypoint.iter().map(String::as_str).collect()),
         privileged: false,
+        force_recreate: false,
     };
 
-    let result = container::run(&docker, run_spec).await?;
-
+    let result = container::create(&docker, run_spec).await?;
+    container::start(&docker, result.id()).await?;
     container::container_logs_to_stdout(docker, result.id()).await?;
+    container::force_remove(docker, result.id()).await?;
 
     Ok(())
 }

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -46,7 +46,7 @@ chown -R {} /tmp/.ssh
     let result = container::create(&docker, run_spec).await?;
     container::start(&docker, result.id()).await?;
     container::container_logs_to_stdout(docker, result.id()).await?;
-    container::force_remove(docker, result.id()).await?;
+    container::remove(docker, result.id(), true).await?;
 
     Ok(())
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -107,6 +107,7 @@ pub struct WorkSpec<'a> {
     pub git_vol_mount: Option<Mount>,
     pub caches: Option<Vec<String>>,
     pub privileged: bool,
+    pub force_recreate: bool,
 }
 
 pub struct RunSpec<'a> {
@@ -119,4 +120,5 @@ pub struct RunSpec<'a> {
     pub mounts: Option<Vec<Mount>>,
     pub entrypoint: Option<Vec<&'a str>>,
     pub privileged: bool,
+    pub force_recreate: bool,
 }


### PR DESCRIPTION
Major changes:
* introduce two new subcommands: `new` and `enter` (they work in a similar manner to `create` and `enter` toolbox). The new command creates a non-started container and all necessary volumes and mounts. The enter command opens an interactive shell to the workspace's container (the first enter command also starts the container)
* keep the container running when terminating an interactive session (current rooz versions would terminate the container which is less than ideal when there is any non-persisted state in the container like background processes running)
* remove --prune switch from the default command and introduce new `rm` subcommand for pruning workspaces.