### PR TITLE
Tmp: Make repo optional + add rm switch

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,8 +64,8 @@ pub struct NewParams {
 #[command(about = "Enters an ephemeral workspace")]
 pub struct TmpParams {
     pub git_ssh_url: Option<String>,
-    #[arg(short, alias = "rm")]
-    pub remove: bool,
+    #[arg(long, help = "Remove container once the session is terminated")]
+    pub rm: bool,
     #[command(flatten)]
     pub work: WorkParams,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,7 +63,9 @@ pub struct NewParams {
 #[derive(Parser, Debug)]
 #[command(about = "Enters an ephemeral workspace")]
 pub struct TmpParams {
-    pub git_ssh_url: String,
+    pub git_ssh_url: Option<String>,
+    #[arg(short, alias = "rm")]
+    pub remove: bool,
     #[command(flatten)]
     pub work: WorkParams,
 }

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -68,7 +68,7 @@ pub async fn new(
                 )
                 .await?;
             }
-            return Ok(container_id)
+            return Ok(container_id);
         }
         Some(url) => {
             match git::clone_repo(
@@ -120,7 +120,7 @@ pub async fn new(
                     if enter {
                         workspace::enter(&docker, &container_id, Some(&clone_dir), &sh).await?;
                     }
-                    return Ok(container_id)
+                    return Ok(container_id);
                 }
                 (None, url) => {
                     let clone_dir = git::get_clone_dir(&work_dir, url);
@@ -132,17 +132,20 @@ pub async fn new(
                     };
                     let container_id = workspace::create(&docker, &work_spec).await?;
                     if enter {
-                        workspace::enter(&docker, &container_id, Some(&clone_dir), &work_spec.shell)
-                            .await?;
+                        workspace::enter(
+                            &docker,
+                            &container_id,
+                            Some(&clone_dir),
+                            &work_spec.shell,
+                        )
+                        .await?;
                     }
-                    return Ok(container_id)
+                    return Ok(container_id);
                 }
                 _ => {
                     unreachable!("Unreachable");
-                    //return Ok("".to_string())
-                },
+                }
             }
         }
     };
 }
-

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -12,7 +12,7 @@ pub async fn new(
     git_ssh_url: Option<String>,
     spec: &WorkParams,
     persistence: Option<WorkspacePersistence>,
-) -> Result<(), Box<dyn std::error::Error + 'static>> {
+) -> Result<String, Box<dyn std::error::Error + 'static>> {
     let ephemeral = persistence.is_none();
 
     let orig_shell = &spec.shell;
@@ -66,8 +66,9 @@ pub async fn new(
                     Some(&work_spec.container_working_dir),
                     &work_spec.shell.as_ref(),
                 )
-                .await?
+                .await?;
             }
+            return Ok(container_id)
         }
         Some(url) => {
             match git::clone_repo(
@@ -117,8 +118,9 @@ pub async fn new(
 
                     let container_id = workspace::create(&docker, &work_spec).await?;
                     if enter {
-                        workspace::enter(&docker, &container_id, Some(&clone_dir), &sh).await?
+                        workspace::enter(&docker, &container_id, Some(&clone_dir), &sh).await?;
                     }
+                    return Ok(container_id)
                 }
                 (None, url) => {
                     let clone_dir = git::get_clone_dir(&work_dir, url);
@@ -131,12 +133,16 @@ pub async fn new(
                     let container_id = workspace::create(&docker, &work_spec).await?;
                     if enter {
                         workspace::enter(&docker, &container_id, Some(&clone_dir), &work_spec.shell)
-                            .await?
+                            .await?;
                     }
+                    return Ok(container_id)
                 }
-                _ => unreachable!("Unreachable"),
+                _ => {
+                    unreachable!("Unreachable");
+                    //return Ok("".to_string())
+                },
             }
         }
     };
-    Ok(())
 }
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,11 +63,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
             cmd::prune::prune_workspace(&docker, &name, force).await?;
         }
         Cli {
-            command: Tmp(TmpParams { git_ssh_url, remove, work }),
+            command: Tmp(TmpParams { git_ssh_url, rm, work }),
             ..
         } => {
             let container_id = cmd::new::new(&docker, git_ssh_url, &work, None).await?;
-            if remove {
+            if rm {
                 container::remove(&docker, &container_id, true).await?;
             }
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
             ..
         } => {
             cmd::new::new(&docker, git_ssh_url, &work, Some(persistence)).await?;
-        },
+        }
         Cli {
             command:
                 Enter(EnterParams {
@@ -63,14 +63,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
             cmd::prune::prune_workspace(&docker, &name, force).await?;
         }
         Cli {
-            command: Tmp(TmpParams { git_ssh_url, rm, work }),
+            command:
+                Tmp(TmpParams {
+                    git_ssh_url,
+                    rm,
+                    work,
+                }),
             ..
         } => {
             let container_id = cmd::new::new(&docker, git_ssh_url, &work, None).await?;
             if rm {
                 container::remove(&docker, &container_id, true).await?;
             }
-        },
+        }
         Cli {
             command:
                 System(cli::System {

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
                     persistence,
                 }),
             ..
-        } => cmd::new::new(&docker, git_ssh_url, &work, Some(persistence)).await?,
+        } => {
+            cmd::new::new(&docker, git_ssh_url, &work, Some(persistence)).await?;
+        },
         Cli {
             command:
                 Enter(EnterParams {
@@ -61,9 +63,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
             cmd::prune::prune_workspace(&docker, &name, force).await?;
         }
         Cli {
-            command: Tmp(TmpParams { git_ssh_url, work }),
+            command: Tmp(TmpParams { git_ssh_url, remove, work }),
             ..
-        } => cmd::new::new(&docker, Some(git_ssh_url), &work, None).await?,
+        } => {
+            let container_id = cmd::new::new(&docker, git_ssh_url, &work, None).await?;
+            if remove {
+                container::remove(&docker, &container_id, true).await?;
+            }
+        },
         Cli {
             command:
                 System(cli::System {


### PR DESCRIPTION
At the moment the `tmp` subcommand let the user open an interactive session into an ephemeral workspace with no state persisted. When terminating a session the container stays there running and needs to be manually removed. Also the `tmp` subcommand assumed a user wants to clone a git repo.

To enable more flexibility let's change the following:
* make git repo optional - so the user can just run a container without any source code in it
* add `--rm` switch that works in the same manner as `docker run`'s `--rm` switch i.e. it makes rooz remove the container after the interactive shell gets terminated.
