### PR TITLE
Init subcommand

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
+        "nonblock",
         "oneshot",
         "Rooz",
         "termion",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,9 @@
 {
     "cSpell.words": [
+        "oneshot",
         "Rooz",
         "termion",
         "TMPFS"
-    ]
+    ],
+    "rust-analyzer.showUnlinkedFileNotification": false
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,10 @@ base64 = "0.21.0"
 #bollard = "0.14.0"
 bollard = { git = "https://github.com/fussybeaver/bollard.git" }
 
-clap = { version = "4.1.6", features = ["derive", "env"] }
+clap = { version = "4.3.1", features = ["derive", "env"] }
 env_logger = "0.10.0"
 futures = "0.3.26"
+hostname = "0.3.1"
 log = "0.4.17"
 rand = "0.8.5"
 regex = "1.7.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rooz"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 
 [dependencies]
@@ -13,6 +13,7 @@ env_logger = "0.10.0"
 futures = "0.3.26"
 hostname = "0.3.1"
 log = "0.4.17"
+nonblock = "0.2.0"
 rand = "0.8.5"
 regex = "1.7.1"
 serde = "1.0.152"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,14 +1,22 @@
 use clap::{Parser, Subcommand};
 
-const DEFAULT_IMAGE: &'static str = "docker.io/bitnami/git:latest";
+use crate::constants;
 
 #[derive(Parser, Debug)]
 #[command(about = "Prunes all rooz resources")]
 pub struct PruneParams {}
 
+#[derive(Parser, Debug)]
+#[command(about = "Initializes rooz system")]
+pub struct InitParams {
+    #[arg(short, long)]
+    pub force: bool,
+}
+
 #[derive(Subcommand, Debug)]
 pub enum SystemCommands {
     Prune(PruneParams),
+    Init(InitParams),
 }
 
 #[derive(Parser, Debug)]
@@ -29,7 +37,7 @@ pub struct WorkspacePersistence {
 
 #[derive(Parser, Debug)]
 pub struct WorkParams {
-    #[arg(short, long, default_value = DEFAULT_IMAGE, env = "ROOZ_IMAGE")]
+    #[arg(short, long, default_value = constants::DEFAULT_IMAGE, env = "ROOZ_IMAGE")]
     pub image: String,
     #[arg(long)]
     pub pull_image: bool,

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -1,0 +1,29 @@
+use bollard::Docker;
+
+use crate::{image, ssh, types::VolumeResult, volume};
+
+pub async fn init(
+    docker: &Docker,
+    image: &str,
+    uid: &str,
+    force: bool,
+) -> Result<(), Box<dyn std::error::Error + 'static>> {
+    let image_id = image::ensure_image(&docker, &image, false).await?;
+
+    match volume::ensure_volume(
+        &docker,
+        ssh::ROOZ_SSH_KEY_VOLUME_NAME.into(),
+        "ssh-key",
+        Some("ssh-key".into()),
+        force,
+    )
+    .await?
+    {
+        VolumeResult::Created { .. } => ssh::init_ssh_key(&docker, &image_id, &uid).await?,
+        VolumeResult::AlreadyExists => {
+            println!("Rooz has been already initialized. Use --force to reinitialize.")
+        }
+    }
+
+    Ok(())
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,3 +1,4 @@
+pub mod init;
 pub mod list;
 pub mod new;
 pub mod prune;

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -3,7 +3,8 @@ use bollard::Docker;
 use crate::{
     cli::{WorkParams, WorkspacePersistence},
     constants, git, image,
-    types::{RoozCfg, WorkSpec}, workspace,
+    types::{RoozCfg, WorkSpec},
+    workspace,
 };
 
 pub async fn new(

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,2 @@
+pub const DEFAULT_IMAGE: &'static str = "docker.io/bitnami/git:latest";
+pub const DEFAULT_UID: &'static str = "1000";

--- a/src/git.rs
+++ b/src/git.rs
@@ -110,7 +110,7 @@ pub async fn clone_repo(
                 "git-clone",
                 &docker,
                 &container_id,
-                false,
+                true,
                 None,
                 None,
                 Some(clone_cmd.iter().map(String::as_str).collect()),

--- a/src/git.rs
+++ b/src/git.rs
@@ -44,7 +44,14 @@ pub async fn git_volume(
 
     let vol_name = git_vol.safe_volume_name()?;
 
-    volume::ensure_volume(docker, &vol_name, &git_vol.role.as_str(), git_vol.key()).await;
+    volume::ensure_volume(
+        docker,
+        &vol_name,
+        &git_vol.role.as_str(),
+        git_vol.key(),
+        false,
+    )
+    .await?;
 
     let git_vol_mount = Mount {
         typ: Some(VOLUME),

--- a/src/image.rs
+++ b/src/image.rs
@@ -59,11 +59,11 @@ pub async fn pull_image(
 pub async fn ensure_image(
     docker: &Docker,
     image: &str,
-    pull: bool,
+    always_pull: bool,
 ) -> Result<String, Box<dyn std::error::Error + 'static>> {
     let image_id = match docker.inspect_image(&image).await {
         Ok(ImageInspect { id, .. }) => {
-            if pull {
+            if always_pull {
                 pull_image(docker, image).await?
             } else {
                 id

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod cmd;
+mod constants;
 mod container;
 mod git;
 mod id;
@@ -13,12 +14,12 @@ mod workspace;
 use crate::cli::{
     Cli,
     Commands::{Enter, List, New, Remove, System, Tmp},
-    ListParams, NewParams, RemoveParams, TmpParams,
+    InitParams, ListParams, NewParams, RemoveParams, TmpParams,
 };
 
 use bollard::Docker;
 use clap::Parser;
-use cli::{EnterParams, PruneParams};
+use cli::EnterParams;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
@@ -79,11 +80,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
         Cli {
             command:
                 System(cli::System {
-                    command: cli::SystemCommands::Prune(PruneParams {}),
+                    command: cli::SystemCommands::Prune(_),
                 }),
             ..
         } => {
             cmd::prune::prune_system(&docker).await?;
+        }
+        Cli {
+            command:
+                System(cli::System {
+                    command: cli::SystemCommands::Init(InitParams { force }),
+                }),
+            ..
+        } => {
+            cmd::init::init(
+                &docker,
+                constants::DEFAULT_IMAGE,
+                constants::DEFAULT_UID,
+                force,
+            )
+            .await?;
         }
     };
     Ok(())

--- a/src/types.rs
+++ b/src/types.rs
@@ -26,7 +26,7 @@ impl ContainerResult {
 
 pub enum VolumeResult {
     Created,
-    Reused,
+    AlreadyExists,
 }
 
 #[derive(Debug, Clone)]

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -2,17 +2,31 @@ use crate::{
     labels, ssh,
     types::{RoozVolume, VolumeResult},
 };
-use bollard::errors::Error::DockerResponseServerError;
 use bollard::models::MountTypeEnum::{TMPFS, VOLUME};
+use bollard::{errors::Error::DockerResponseServerError, volume::RemoveVolumeOptions};
 use bollard::{service::Mount, volume::CreateVolumeOptions, Docker};
 use std::{collections::HashMap, path::Path};
+
+async fn create(
+    docker: &Docker,
+    options: CreateVolumeOptions<&str>,
+) -> Result<VolumeResult, Box<dyn std::error::Error + 'static>> {
+    match docker.create_volume(options).await {
+        Ok(v) => {
+            log::debug!("Volume created: {:?}", v.name);
+            return Ok(VolumeResult::Created);
+        }
+        Err(e) => panic!("{}", e),
+    }
+}
 
 pub async fn ensure_volume(
     docker: &Docker,
     name: &str,
     role: &str,
     workspace_key: Option<String>,
-) -> VolumeResult {
+    force_recreate: bool,
+) -> Result<VolumeResult, Box<dyn std::error::Error + 'static>> {
     let workspace_key = workspace_key.unwrap_or_default();
     let labels = HashMap::from([
         (labels::ROOZ, "true"),
@@ -27,20 +41,19 @@ pub async fn ensure_volume(
     };
 
     match docker.inspect_volume(&name).await {
+        Ok(_) if force_recreate => {
+            let options = RemoveVolumeOptions { force: true };
+            docker.remove_volume(&name, Some(options)).await?;
+            return create(docker, create_vol_options).await;
+        }
         Ok(_) => {
             log::debug!("Reusing an existing {} volume", &name);
-            VolumeResult::Reused
+            return Ok(VolumeResult::AlreadyExists);
         }
         Err(DockerResponseServerError {
             status_code: 404,
             message: _,
-        }) => match docker.create_volume(create_vol_options).await {
-            Ok(v) => {
-                log::debug!("Volume created: {:?}", v.name);
-                VolumeResult::Created
-            }
-            Err(e) => panic!("{}", e),
-        },
+        }) => return create(docker, create_vol_options).await,
         Err(e) => panic!("{}", e),
     }
 }
@@ -52,11 +65,7 @@ pub async fn ensure_mounts(
     home_dir: &str,
 ) -> Result<Vec<Mount>, Box<dyn std::error::Error + 'static>> {
     let mut mounts = vec![ssh::mount(
-        Path::new(home_dir)
-            .join(".ssh")
-            .to_string_lossy()
-            .to_string()
-            .as_ref(),
+        Path::new(home_dir).join(".ssh").to_string_lossy().as_ref(),
     )];
 
     for v in volumes {
@@ -64,7 +73,7 @@ pub async fn ensure_mounts(
         let vol_name = v.safe_volume_name()?;
 
         if !is_ephemeral {
-            ensure_volume(&docker, &vol_name, v.role.as_str(), v.key()).await;
+            ensure_volume(&docker, &vol_name, v.role.as_str(), v.key(), false).await?;
         }
 
         let mount = Mount {


### PR DESCRIPTION
This PR:
* introduces `system init` subcommand that can generate an ed25519 key explicitly rather than implicitly with the first run. It also comes with a `--force` switch to re-generate the key if necessary
* runs git clone interactively so the user can accept new hosts to `known_hosts` file 
* makes SSH mount RW so `known_hosts` can be persisted and `~/.ssh/config` overridden
* fixes a bug with termion's `async_stdin()` multiple usage (dropping characters) by replacing it with [nonblock](https://crates.io/crates/nonblock) (via [this comment](https://github.com/alexcrichton/ssh2-rs/issues/128#issuecomment-1071923093))

Closes #8 