### PR TITLE
Experimental shell complete (static)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rooz"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 
 [dependencies]
@@ -9,6 +9,7 @@ base64 = "0.21.0"
 bollard = { git = "https://github.com/fussybeaver/bollard.git" }
 
 clap = { version = "4.3.1", features = ["derive", "env"] }
+clap_complete = "4.3.1"
 env_logger = "0.10.0"
 futures = "0.3.26"
 hostname = "0.3.1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use clap_complete::Shell;
 
 use crate::constants;
 
@@ -13,10 +14,17 @@ pub struct InitParams {
     pub force: bool,
 }
 
+#[derive(Parser, Debug)]
+#[command(about = "Initializes rooz system")]
+pub struct CompletionParams {
+    pub shell: Shell
+}
+
 #[derive(Subcommand, Debug)]
 pub enum SystemCommands {
     Prune(PruneParams),
     Init(InitParams),
+    Completion(CompletionParams),
 }
 
 #[derive(Parser, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,17 +11,20 @@ mod types;
 mod volume;
 mod workspace;
 
+use std::io;
+
 use crate::{
     cli::{
         Cli,
         Commands::{Enter, List, New, Remove, Stop, System, Tmp},
-        InitParams, ListParams, NewParams, RemoveParams, StopParams, TmpParams,
+        InitParams, ListParams, NewParams, RemoveParams, StopParams, TmpParams, CompletionParams,
     },
     types::RoozCfg,
 };
 
 use bollard::Docker;
-use clap::Parser;
+use clap::{CommandFactory, Parser};
+use clap_complete::generate;
 use cli::EnterParams;
 
 #[tokio::main]
@@ -143,6 +146,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
                 force,
             )
             .await?
+        }
+
+        Cli {
+            command:
+                System(cli::System {
+                    command: cli::SystemCommands::Completion(CompletionParams {shell}),
+                }),
+        } => {
+            let mut cli = Cli::command()
+                .disable_help_flag(true)
+                .disable_help_subcommand(true);
+            let name = &cli.get_name().to_string();
+            generate(
+                shell,
+                &mut cli,
+                name,
+                &mut io::stdout(),
+            );
         }
     };
     Ok(())


### PR DESCRIPTION
This PR introduces shell completion. This is only a static completion. It would be great to complete `enter`, `stop` and `rm` commands too but this requires clap dynamic completion to get implemented.