### PR TITLE
Multiple fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rooz"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 
 [dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,7 @@ pub struct InitParams {
 #[derive(Parser, Debug)]
 #[command(about = "Initializes rooz system")]
 pub struct CompletionParams {
-    pub shell: Shell
+    pub shell: Shell,
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,24 +1,21 @@
-use bollard::models::MountTypeEnum::{TMPFS, VOLUME};
+use bollard::models::MountTypeEnum::VOLUME;
 use bollard::{service::Mount, Docker};
 
 use crate::labels::Labels;
+use crate::types::GitCloneSpec;
 use crate::{
     container, id, ssh,
     types::{ContainerResult, RoozCfg, RoozVolume, RoozVolumeRole, RoozVolumeSharing, RunSpec},
     volume,
 };
 
-//TODO: return volume from clone_repo and make this private
-pub fn get_clone_dir(root_dir: &str, git_ssh_url: Option<String>) -> String {
-    let clone_work_dir = match git_ssh_url {
-        Some(url) => url
-            .split(&['/'])
-            .last()
-            .unwrap_or("repo")
-            .replace(".git", "")
-            .to_string(),
-        None => "".into(),
-    };
+fn get_clone_dir(root_dir: &str, git_ssh_url: &str) -> String {
+    let clone_work_dir = git_ssh_url
+        .split(&['/'])
+        .last()
+        .unwrap_or("repo")
+        .replace(".git", "")
+        .to_string();
 
     log::debug!("Clone dir: {}", &clone_work_dir);
 
@@ -28,13 +25,11 @@ pub fn get_clone_dir(root_dir: &str, git_ssh_url: Option<String>) -> String {
     work_dir
 }
 
-//TODO: return volume from clone_repo and make this private
-pub async fn git_volume(
+async fn git_volume(
     docker: &Docker,
     target_path: &str,
     workspace_key: &str,
-    ephemeral: bool,
-) -> Result<Mount, Box<dyn std::error::Error + 'static>> {
+) -> Result<(String, Mount), Box<dyn std::error::Error + 'static>> {
     let git_vol = RoozVolume {
         path: target_path.into(),
         sharing: RoozVolumeSharing::Exclusive {
@@ -44,47 +39,40 @@ pub async fn git_volume(
     };
 
     let vol_name = git_vol.safe_volume_name()?;
+    let v = vol_name.to_string();
 
-    if !ephemeral {
-        volume::ensure_volume(
-            docker,
-            &vol_name,
-            &git_vol.role.as_str(),
-            git_vol.key(),
-            false,
-        )
-        .await?;
-    }
+    volume::ensure_volume(
+        docker,
+        &vol_name,
+        &git_vol.role.as_str(),
+        git_vol.key(),
+        false,
+    )
+    .await?;
 
     let git_vol_mount = Mount {
-        typ: Some(if ephemeral { TMPFS } else { VOLUME }),
-        source: if ephemeral {
-            None
-        } else {
-            Some(vol_name.into())
-        },
+        typ: Some(VOLUME),
+        source: Some(vol_name.into()),
         target: Some(git_vol.path.into()),
         read_only: Some(false),
         ..Default::default()
     };
 
-    Ok(git_vol_mount)
+    Ok((v, git_vol_mount))
 }
 
 pub async fn clone_repo(
     docker: &Docker,
     image: &str,
-    image_id: &str,
     uid: &str,
-    git_ssh_url: Option<String>,
+    url: &str,
     workspace_key: &str,
-    ephemeral: bool,
-) -> Result<(Option<RoozCfg>, Option<String>), Box<dyn std::error::Error + 'static>> {
-    if let Some(url) = git_ssh_url.clone() {
-        let working_dir = "/tmp/git";
-        let clone_dir = format!("{}", &working_dir);
+    working_dir: &str,
+) -> Result<(Option<RoozCfg>, GitCloneSpec), Box<dyn std::error::Error + 'static>> {
+    let tmp_working_dir = "/tmp/git";
+    let clone_dir = format!("{}", &tmp_working_dir);
 
-        let clone_cmd = container::inject(
+    let clone_cmd = container::inject(
             format!(
                     r#"export GIT_SSH_COMMAND="ssh -i /tmp/.ssh/id_ed25519 -o UserKnownHostsFile=/tmp/.ssh/known_hosts"
                     ls "{}/.git" > /dev/null 2>&1 || git clone {} {}"#,
@@ -94,65 +82,71 @@ pub async fn clone_repo(
             "clone.sh",
         );
 
-        let git_vol_mount = git_volume(docker, working_dir, workspace_key, ephemeral).await?;
-        let labels = Labels::new(Some(&workspace_key), Some("git"));
+    let (_, tmp_git_vol_mount) = git_volume(docker, tmp_working_dir, workspace_key).await?;
+    let labels = Labels::new(Some(&workspace_key), Some("git"));
 
-        let run_spec = RunSpec {
-            reason: "git-clone",
-            image,
-            image_id,
-            user: Some(&uid),
-            work_dir: None,
-            container_name: &id::random_suffix("rooz-git"),
-            workspace_key,
-            mounts: Some(vec![git_vol_mount.clone(), ssh::mount("/tmp/.ssh")]),
-            entrypoint: Some(vec!["cat"]),
-            privileged: false,
-            force_recreate: false,
-            auto_remove: true,
-            labels: (&labels).into(),
-            ..Default::default()
-        };
+    let run_spec = RunSpec {
+        reason: "git-clone",
+        image,
+        user: Some(&uid),
+        work_dir: None,
+        container_name: &id::random_suffix("rooz-git"),
+        workspace_key,
+        mounts: Some(vec![tmp_git_vol_mount.clone(), ssh::mount("/tmp/.ssh")]),
+        entrypoint: Some(vec!["cat"]),
+        privileged: false,
+        force_recreate: false,
+        auto_remove: true,
+        labels: (&labels).into(),
+        ..Default::default()
+    };
 
-        let container_result = container::create(&docker, run_spec).await?;
-        container::start(docker, container_result.id()).await?;
-        let container_id = container_result.id();
+    let container_result = container::create(&docker, run_spec).await?;
+    container::start(docker, container_result.id()).await?;
+    let container_id = container_result.id();
 
-        if let ContainerResult::Created { .. } = container_result {
-            container::exec_tty(
-                "git-clone",
-                &docker,
-                &container_id,
-                true,
-                None,
-                None,
-                Some(clone_cmd.iter().map(String::as_str).collect()),
-            )
-            .await?;
-        };
-
-        let rooz_cfg = container::exec_output(
-            "rooz-toml",
+    if let ContainerResult::Created { .. } = container_result {
+        container::exec_tty(
+            "git-clone",
             &docker,
             &container_id,
+            true,
             None,
-            Some(vec![
-                "cat",
-                format!("{}/{}", clone_dir, ".rooz.toml").as_ref(),
-            ]),
+            None,
+            Some(clone_cmd.iter().map(String::as_str).collect()),
         )
         .await?;
+    };
 
-        log::debug!("Repo config result: {}", &rooz_cfg);
+    let rooz_cfg = container::exec_output(
+        "rooz-toml",
+        &docker,
+        &container_id,
+        None,
+        Some(vec![
+            "cat",
+            format!("{}/{}", clone_dir, ".rooz.toml").as_ref(),
+        ]),
+    )
+    .await?;
 
-        container::remove(docker, &container_id, true).await?;
+    log::debug!("Repo config result: {}", &rooz_cfg);
 
-        let cfg = RoozCfg::from_string(rooz_cfg).ok();
-        match cfg {
-            Some(cfg) => Ok((Some(cfg), Some(url))),
-            None => Ok((None, Some(url))),
-        }
-    } else {
-        Ok((None, None))
+    container::remove(docker, &container_id, true).await?;
+
+    let cfg = RoozCfg::from_string(rooz_cfg).ok();
+
+    let clone_dir = get_clone_dir(working_dir, url);
+    let (vol_name, mount) = git_volume(docker, &clone_dir, workspace_key).await?;
+
+    let work_spec = GitCloneSpec {
+        vol_name,
+        dir: clone_dir,
+        mount,
+    };
+
+    match cfg {
+        Some(cfg) => Ok((Some(cfg), work_spec)),
+        None => Ok((None, work_spec)),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use crate::{
     cli::{
         Cli,
         Commands::{Enter, List, New, Remove, Stop, System, Tmp},
-        InitParams, ListParams, NewParams, RemoveParams, StopParams, TmpParams, CompletionParams,
+        CompletionParams, InitParams, ListParams, NewParams, RemoveParams, StopParams, TmpParams,
     },
     types::RoozCfg,
 };
@@ -72,6 +72,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
                 work_dir.as_deref(),
                 &shell,
                 container.as_deref(),
+                None,
+                false,
             )
             .await?
         }
@@ -118,8 +120,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
             command: Tmp(TmpParams { work }),
             ..
         } => {
-            let container_id = cmd::new::new(&docker, &work, None, None).await?;
-            container::remove(&docker, &container_id, true).await?;
+            cmd::new::new(&docker, &work, None, None).await?;
         }
 
         Cli {
@@ -151,19 +152,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
         Cli {
             command:
                 System(cli::System {
-                    command: cli::SystemCommands::Completion(CompletionParams {shell}),
+                    command: cli::SystemCommands::Completion(CompletionParams { shell }),
                 }),
         } => {
             let mut cli = Cli::command()
                 .disable_help_flag(true)
                 .disable_help_subcommand(true);
             let name = &cli.get_name().to_string();
-            generate(
-                shell,
-                &mut cli,
-                name,
-                &mut io::stdout(),
-            );
+            generate(shell, &mut cli, name, &mut io::stdout());
         }
     };
     Ok(())

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -30,7 +30,6 @@ chmod 400 $KEYFILE && chown -R {} /tmp/.ssh
     let run_spec = RunSpec {
         reason: "init-ssh",
         image,
-        image_id: "ignore",
         user: Some("root"),
         work_dir: None,
         container_name: "rooz-init-ssh",

--- a/src/types.rs
+++ b/src/types.rs
@@ -118,9 +118,16 @@ impl RoozVolume {
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct GitCloneSpec {
+    pub vol_name: String,
+    pub dir: String,
+    pub mount: Mount,
+}
+
+#[derive(Clone, Debug)]
 pub struct WorkSpec<'a> {
     pub image: &'a str,
-    pub image_id: &'a str,
     pub shell: &'a str,
     pub uid: &'a str,
     pub user: &'a str,
@@ -136,10 +143,30 @@ pub struct WorkSpec<'a> {
     pub network: Option<&'a str>,
 }
 
+impl Default for WorkSpec<'_> {
+    fn default() -> Self {
+        Self {
+            image: Default::default(),
+            shell: Default::default(),
+            uid: Default::default(),
+            user: Default::default(),
+            container_working_dir: Default::default(),
+            container_name: Default::default(),
+            workspace_key: Default::default(),
+            labels: Default::default(),
+            ephemeral: false,
+            git_vol_mount: None,
+            caches: None,
+            privileged: false,
+            force_recreate: false,
+            network: None,
+        }
+    }
+}
+
 pub struct RunSpec<'a> {
     pub reason: &'a str,
     pub image: &'a str,
-    pub image_id: &'a str,
     pub user: Option<&'a str>,
     pub work_dir: Option<&'a str>,
     pub container_name: &'a str,
@@ -160,7 +187,6 @@ impl Default for RunSpec<'_> {
         Self {
             reason: Default::default(),
             image: Default::default(),
-            image_id: Default::default(),
             user: None,
             work_dir: None,
             container_name: Default::default(),

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -21,6 +21,21 @@ async fn create(
     }
 }
 
+pub async fn remove(
+    docker: &Docker,
+    name: &str,
+    force: bool,
+) -> Result<(), Box<dyn std::error::Error + 'static>> {
+    let options = RemoveVolumeOptions { force };
+    match docker.remove_volume(name, Some(options)).await {
+        Ok(_) => {
+            log::debug!("Volume removed: {}", &name);
+            return Ok(());
+        }
+        Err(e) => panic!("{}", e),
+    }
+}
+
 pub async fn ensure_volume(
     docker: &Docker,
     name: &str,


### PR DESCRIPTION
This PR has the following changes:
* fix: ephemeral behaviour (the `tmp` sumcommand) with git. The git volume has been recently changed to tmpfs for ephemeral runs but it can't be that way as clone is performed by a different container, hence it must be a normal persisted volume. To make it behave like an ephemeral vol it now gets removed after the container stops, (and gets auto-removed).
* fix: improve the experience when user tries to create a workspace with a name that already exists. It now suggests entering or using `--force` rather than panicking.
* fix: revert to using the default image for git clone (i.e. disable auto-overriding that via the `--image` param). That way the clone still works even if the `--image` doesn't have git installed. 
* chore: refac the whole git volume/clone dir code so its more intuitive
* chore: remove the `image_id` parameter from code as the `auto-recreate when a new image_id is found` behaviour doesn't exist anymore