### PR TITLE
Configuration improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rooz"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 
 [dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,6 +91,8 @@ pub struct NewParams {
 pub struct TmpParams {
     #[command(flatten)]
     pub work: WorkParams,
+    #[arg(short, long)]
+    pub root: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,6 @@
 use clap::{Parser, Subcommand};
 use clap_complete::Shell;
 
-use crate::constants;
-
 #[derive(Parser, Debug)]
 #[command(about = "Prunes all rooz resources")]
 pub struct PruneParams {}
@@ -47,18 +45,25 @@ pub struct WorkspacePersistence {
 pub struct WorkParams {
     #[arg(short, long, alias = "git")]
     pub git_ssh_url: Option<String>,
-    #[arg(short, long, default_value = constants::DEFAULT_IMAGE, env = "ROOZ_IMAGE")]
-    pub image: String,
+    #[arg(long, hide = true, env = "ROOZ_IMAGE")]
+    pub env_image: Option<String>,
+    #[arg(short, long)]
+    pub image: Option<String>,
     #[arg(long)]
     pub pull_image: bool,
-    #[arg(short, long, default_value = "bash", env = "ROOZ_SHELL")]
-    pub shell: String,
-    #[arg(short, long, default_value = "rooz_user", env = "ROOZ_USER")]
-    pub user: String,
+    #[arg(long, hide = true, env = "ROOZ_SHELL")]
+    pub env_shell: Option<String>,
+    #[arg(short, long)]
+    pub shell: Option<String>,
+    #[arg(long, hide=true, env = "ROOZ_USER")]
+    pub env_user: Option<String>,
+    #[arg(short, long)]
+    pub user: Option<String>,
+    #[arg(long, hide = true, env = "ROOZ_CACHES", use_value_delimiter = true)]
+    pub env_caches: Option<Vec<String>>,
     #[arg(
         short,
         long,
-        env = "ROOZ_CACHES",
         use_value_delimiter = true,
         help = "Enables defining global shared caches"
     )]
@@ -94,6 +99,8 @@ pub struct EnterParams {
     pub name: String,
     #[arg(short, long, default_value = "bash", env = "ROOZ_SHELL")]
     pub shell: String,
+    #[arg(short, long)]
+    pub root: bool,
     #[arg(short, long)]
     pub work_dir: Option<String>,
     #[arg(short, long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,7 +55,7 @@ pub struct WorkParams {
     pub env_shell: Option<String>,
     #[arg(short, long)]
     pub shell: Option<String>,
-    #[arg(long, hide=true, env = "ROOZ_USER")]
+    #[arg(long, hide = true, env = "ROOZ_USER")]
     pub env_user: Option<String>,
     #[arg(short, long)]
     pub user: Option<String>,

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -1,26 +1,21 @@
-use bollard::network::CreateNetworkOptions;
-
 use crate::{
     backend::WorkspaceApi,
     cli::{WorkParams, WorkspacePersistence},
     constants,
     labels::{self, Labels},
-    types::{RoozCfg, RunSpec, WorkSpec},
+    types::{RoozCfg, WorkSpec},
 };
 
 impl<'a> WorkspaceApi<'a> {
     pub async fn new(
         &self,
         spec: &WorkParams,
-        config: Option<RoozCfg>,
+        cli_config: Option<RoozCfg>,
         persistence: Option<WorkspacePersistence>,
     ) -> Result<String, Box<dyn std::error::Error + 'static>> {
         let ephemeral = persistence.is_none();
-
-        let orig_shell = &spec.shell;
-        let orig_user = &spec.user;
         let orig_uid = constants::DEFAULT_UID.to_string();
-        let orig_image = &spec.image;
+
         let (workspace_key, force, enter) = match persistence {
             Some(p) => (p.name.to_string(), p.force, p.enter),
             None => (crate::id::random_suffix("tmp"), false, true),
@@ -31,80 +26,42 @@ impl<'a> WorkspaceApi<'a> {
             self.remove(&workspace_key, true).await?;
         }
 
-        let labels_sidecar = Labels::new(Some(&workspace_key), Some(labels::ROLE_SIDECAR));
-
-        let network = if let Some(RoozCfg {
-            sidecars: Some(_), ..
-        }) = &config
-        {
-            let network_options = CreateNetworkOptions::<&str> {
-                name: &workspace_key,
-                check_duplicate: true,
-                labels: (&labels).into(),
-
-                ..Default::default()
-            };
-
-            self.api.client.create_network(network_options).await?;
-            Some(workspace_key.as_ref())
-        } else {
-            None
-        };
-
-        if let Some(RoozCfg {
-            sidecars: Some(sidecars),
-            ..
-        }) = &config
-        {
-            for (name, s) in sidecars {
-                log::debug!("Process sidecar: {}", name);
-                self.api.image.ensure(&s.image, spec.pull_image).await?;
-                let container_name = format!("{}-{}", workspace_key, name);
-                self.api
-                    .container
-                    .create(RunSpec {
-                        container_name: &container_name,
-                        image: &s.image,
-                        force_recreate: force,
-                        workspace_key: &workspace_key,
-                        labels: (&labels_sidecar).into(),
-                        env: s.env.clone(),
-                        network,
-                        network_aliases: Some(vec![name.into()]),
-                        ..Default::default()
-                    })
-                    .await?;
-            }
-        }
-
-        self.api.image.ensure(&orig_image, spec.pull_image).await?;
         self.api
             .image
             .ensure(constants::DEFAULT_IMAGE, spec.pull_image)
             .await?;
 
+        let orig_user = &RoozCfg::user(spec, &cli_config, &None);
         let home_dir = format!("/home/{}", &orig_user);
         let work_dir = format!("{}/work", &home_dir);
 
         let work_spec = WorkSpec {
-            image: &orig_image,
-            shell: &orig_shell,
             uid: &orig_uid,
-            user: &orig_user,
             container_working_dir: &work_dir,
             container_name: &workspace_key,
             workspace_key: &workspace_key,
             labels: (&labels).into(),
             ephemeral,
-            git_vol_mount: None,
-            caches: spec.caches.clone(),
             privileged: spec.privileged,
             force_recreate: force,
-            network,
+            user: orig_user,
+            ..Default::default()
         };
 
         match &spec.git_ssh_url {
             None => {
+                let image = &RoozCfg::image(spec, &cli_config, &None);
+                self.api.image.ensure(&image, spec.pull_image).await?;
+
+                let network = self.ensure_sidecars(&RoozCfg::sidecars(&cli_config, &None), &labels, &workspace_key, force, spec.pull_image).await?;
+                let work_spec = WorkSpec {
+                    image,
+                    shell: &RoozCfg::shell(spec, &cli_config, &None),
+                    caches: Some(RoozCfg::caches(spec, &cli_config, &None)),
+                    network: network.as_deref(),
+                    ..work_spec
+                };
+                
                 let ws = self.create(&work_spec).await?;
                 let volumes = ws.volumes;
                 if enter {
@@ -116,6 +73,7 @@ impl<'a> WorkspaceApi<'a> {
                         None,
                         volumes,
                         &orig_uid,
+                        None,
                         ephemeral,
                     )
                     .await?;
@@ -135,65 +93,27 @@ impl<'a> WorkspaceApi<'a> {
                     .await?
                 {
                     (
-                        Some(RoozCfg {
-                            image: Some(img),
-                            shell,
-                            caches: repo_caches,
-                            ..
-                        }),
+                        repo_config,
                         git_spec,
                     ) => {
-                        log::debug!("Image config read from .rooz.toml in the cloned repo");
-                        self.api.image.ensure(&img, spec.pull_image).await?;
-                        let sh = shell.or(Some(orig_shell.to_string())).unwrap();
-                        let caches = spec.caches.clone();
-                        let mut all_caches = vec![];
-                        if let Some(caches) = caches {
-                            all_caches.extend(caches);
-                        }
-                        if let Some(caches) = repo_caches {
-                            all_caches.extend(caches);
-                        };
+                        log::debug!("Config read from .rooz.toml in the cloned repo");
 
-                        all_caches.dedup();
-
+                        let image = &RoozCfg::image(spec, &cli_config, &repo_config);
+                        self.api.image.ensure(&image, spec.pull_image).await?;
+                        let network = self.ensure_sidecars(&RoozCfg::sidecars(&cli_config, &repo_config), &labels, &workspace_key, force, spec.pull_image).await?;
                         let work_spec = WorkSpec {
-                            image: &img,
-                            shell: &sh,
+                            image,
+                            shell: &RoozCfg::shell(spec, &cli_config, &repo_config),
+                            caches: Some(RoozCfg::caches(spec, &cli_config, &repo_config)),
                             container_working_dir: &git_spec.dir,
                             git_vol_mount: Some(git_spec.mount),
-                            caches: Some(all_caches),
+                            network: network.as_deref(),
                             ..work_spec
                         };
 
                         let ws = self.create(&work_spec).await?;
                         let mut volumes = ws.volumes;
                         volumes.push(git_spec.volume);
-                        if enter {
-                            self.enter(
-                                &workspace_key,
-                                Some(&git_spec.dir),
-                                Some(&home_dir),
-                                &sh,
-                                None,
-                                volumes,
-                                &orig_uid,
-                                ephemeral,
-                            )
-                            .await?;
-                        }
-                        return Ok(ws.container_id);
-                    }
-                    (None, git_spec) => {
-                        let work_spec = WorkSpec {
-                            container_working_dir: &git_spec.dir,
-                            git_vol_mount: Some(git_spec.mount),
-                            ..work_spec
-                        };
-                        let ws = self.create(&work_spec).await?;
-                        let mut volumes = ws.volumes;
-                        volumes.push(git_spec.volume);
-
                         if enter {
                             self.enter(
                                 &workspace_key,
@@ -203,15 +123,12 @@ impl<'a> WorkspaceApi<'a> {
                                 None,
                                 volumes,
                                 &orig_uid,
+                                None,
                                 ephemeral,
                             )
                             .await?;
                         }
                         return Ok(ws.container_id);
-                    }
-                    s => {
-                        println!("{:?}", s);
-                        unreachable!("Unreachable");
                     }
                 }
             }

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -12,6 +12,7 @@ impl<'a> WorkspaceApi<'a> {
         spec: &WorkParams,
         cli_config: Option<RoozCfg>,
         persistence: Option<WorkspacePersistence>,
+        root: bool,
     ) -> Result<String, Box<dyn std::error::Error + 'static>> {
         let ephemeral = persistence.is_none();
         let orig_uid = constants::DEFAULT_UID.to_string();
@@ -81,7 +82,7 @@ impl<'a> WorkspaceApi<'a> {
                         None,
                         volumes,
                         &orig_uid,
-                        false,
+                        root,
                         ephemeral,
                     )
                     .await?;
@@ -136,7 +137,7 @@ impl<'a> WorkspaceApi<'a> {
                                 None,
                                 volumes,
                                 &orig_uid,
-                                false,
+                                root,
                                 ephemeral,
                             )
                             .await?;

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -53,7 +53,15 @@ impl<'a> WorkspaceApi<'a> {
                 let image = &RoozCfg::image(spec, &cli_config, &None);
                 self.api.image.ensure(&image, spec.pull_image).await?;
 
-                let network = self.ensure_sidecars(&RoozCfg::sidecars(&cli_config, &None), &labels, &workspace_key, force, spec.pull_image).await?;
+                let network = self
+                    .ensure_sidecars(
+                        &RoozCfg::sidecars(&cli_config, &None),
+                        &labels,
+                        &workspace_key,
+                        force,
+                        spec.pull_image,
+                    )
+                    .await?;
                 let work_spec = WorkSpec {
                     image,
                     shell: &RoozCfg::shell(spec, &cli_config, &None),
@@ -61,7 +69,7 @@ impl<'a> WorkspaceApi<'a> {
                     network: network.as_deref(),
                     ..work_spec
                 };
-                
+
                 let ws = self.create(&work_spec).await?;
                 let volumes = ws.volumes;
                 if enter {
@@ -73,7 +81,7 @@ impl<'a> WorkspaceApi<'a> {
                         None,
                         volumes,
                         &orig_uid,
-                        None,
+                        false,
                         ephemeral,
                     )
                     .await?;
@@ -92,15 +100,20 @@ impl<'a> WorkspaceApi<'a> {
                     )
                     .await?
                 {
-                    (
-                        repo_config,
-                        git_spec,
-                    ) => {
+                    (repo_config, git_spec) => {
                         log::debug!("Config read from .rooz.toml in the cloned repo");
 
                         let image = &RoozCfg::image(spec, &cli_config, &repo_config);
                         self.api.image.ensure(&image, spec.pull_image).await?;
-                        let network = self.ensure_sidecars(&RoozCfg::sidecars(&cli_config, &repo_config), &labels, &workspace_key, force, spec.pull_image).await?;
+                        let network = self
+                            .ensure_sidecars(
+                                &RoozCfg::sidecars(&cli_config, &repo_config),
+                                &labels,
+                                &workspace_key,
+                                force,
+                                spec.pull_image,
+                            )
+                            .await?;
                         let work_spec = WorkSpec {
                             image,
                             shell: &RoozCfg::shell(spec, &cli_config, &repo_config),
@@ -123,7 +136,7 @@ impl<'a> WorkspaceApi<'a> {
                                 None,
                                 volumes,
                                 &orig_uid,
-                                None,
+                                false,
                                 ephemeral,
                             )
                             .await?;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,3 +1,6 @@
 pub const DEFAULT_IMAGE: &'static str = "docker.io/bitnami/git:latest";
+pub const DEFAULT_SHELL: &'static str = "sh";
+pub const DEFAULT_USER: &'static str = "rooz_user";
 pub const DEFAULT_UID: &'static str = "1000";
-pub const ROOT: &'static str = "root";
+pub const ROOT_UID: &'static str = "0";
+pub const ROOT_USER: &'static str = "root";

--- a/src/container.rs
+++ b/src/container.rs
@@ -102,10 +102,11 @@ impl<'a> ContainerApi<'a> {
         spec: RunSpec<'a>,
     ) -> Result<ContainerResult, Box<dyn std::error::Error + 'static>> {
         log::debug!(
-            "[{}]: Creating container - name: {}, user: {}, image: {}, auto-remove: {}",
+            "[{}]: Creating container - name: {}, uid: {}, user: {}, image: {}, auto-remove: {}",
             &spec.reason,
             spec.container_name,
-            spec.user.unwrap_or_default(),
+            spec.uid,
+            spec.user,
             spec.image,
             spec.auto_remove,
         );
@@ -144,6 +145,9 @@ impl<'a> ContainerApi<'a> {
 
                 let mut env_kv = vec![
                     KeyValue::new("ROOZ_META_IMAGE", &spec.image),
+                    KeyValue::new("ROOZ_META_UID", &spec.uid),
+                    KeyValue::new("ROOZ_META_USER", &spec.user),
+                    KeyValue::new("ROOZ_META_HOME", &spec.home_dir),
                     KeyValue::new("ROOZ_META_WORKSPACE", &spec.workspace_key),
                     KeyValue::new("ROOZ_META_CONTAINER_NAME", &spec.container_name),
                 ];
@@ -158,7 +162,7 @@ impl<'a> ContainerApi<'a> {
                     image: Some(spec.image),
                     entrypoint: spec.entrypoint,
                     working_dir: spec.work_dir,
-                    user: spec.user,
+                    user: Some(spec.uid),
                     attach_stdin: Some(true),
                     attach_stdout: Some(true),
                     attach_stderr: Some(true),

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -161,7 +161,9 @@ impl<'a> ExecApi<'a> {
         user: Option<&str>,
         cmd: Option<Vec<&str>>,
     ) -> Result<String, Box<dyn std::error::Error + 'static>> {
-        let exec_id = self.create_exec(reason, container_id, None, user, cmd).await?;
+        let exec_id = self
+            .create_exec(reason, container_id, None, user, cmd)
+            .await?;
         if let StartExecResults::Attached { output, .. } =
             self.client.start_exec(&exec_id, None).await?
         {
@@ -177,7 +179,6 @@ impl<'a> ExecApi<'a> {
         uid: &str,
         dir: &str,
     ) -> Result<(), Box<dyn std::error::Error + 'static>> {
-
         if let ContainerBackend::Podman = self.backend {
             log::debug!("Podman won't need chown. Skipping");
             return Ok(());
@@ -203,7 +204,6 @@ impl<'a> ExecApi<'a> {
         &self,
         container_id: &str,
     ) -> Result<(), Box<dyn std::error::Error + 'static>> {
-
         let ensure_user_cmd = container::inject(
             format!(
                     r#"whoami > /dev/null 2>&1 && [ "$(whoami)" = "$ROOZ_META_USER" ] || \

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,8 +1,7 @@
 use bollard::models::MountTypeEnum::VOLUME;
 use bollard::service::Mount;
 
-use crate::backend::{ContainerBackend, GitApi};
-use crate::constants;
+use crate::backend::GitApi;
 use crate::labels::Labels;
 use crate::types::GitCloneSpec;
 use crate::{
@@ -103,7 +102,6 @@ impl<'a> GitApi<'a> {
         let container_id = container_result.id();
 
         if let ContainerResult::Created { .. } = container_result {
-
             self.api.exec.ensure_user(container_id).await?;
             self.api.exec.chown(&container_id, uid, &clone_dir).await?;
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -85,11 +85,7 @@ impl<'a> GitApi<'a> {
         let run_spec = RunSpec {
             reason: "git-clone",
             image,
-            user: Some(if let ContainerBackend::Podman = self.api.backend {
-                &uid
-            } else {
-                constants::ROOT
-            }),
+            uid: &uid,
             work_dir: None,
             container_name: &id::random_suffix("rooz-git"),
             workspace_key,
@@ -107,6 +103,10 @@ impl<'a> GitApi<'a> {
         let container_id = container_result.id();
 
         if let ContainerResult::Created { .. } = container_result {
+
+            self.api.exec.ensure_user(container_id).await?;
+            self.api.exec.chown(&container_id, uid, &clone_dir).await?;
+
             self.api
                 .exec
                 .tty(
@@ -118,7 +118,6 @@ impl<'a> GitApi<'a> {
                     Some(clone_cmd.iter().map(String::as_str).collect()),
                 )
                 .await?;
-            self.api.exec.chown(&container_id, uid, &clone_dir).await?;
         };
 
         let rooz_cfg = self

--- a/src/image.rs
+++ b/src/image.rs
@@ -62,6 +62,8 @@ impl<'a> ImageApi<'a> {
         image: &str,
         always_pull: bool,
     ) -> Result<String, Box<dyn std::error::Error + 'static>> {
+        log::debug!("Ensuring image: {}", &image);
+
         let image_id = match self.client.inspect_image(&image).await {
             Ok(ImageInspect { id, .. }) => {
                 if always_pull {

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
                     container.as_deref(),
                     vec![],
                     constants::DEFAULT_UID,
-                    if root { Some(constants::ROOT_USER)} else { None },
+                    root,
                     false,
                 )
                 .await?

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod git;
 mod id;
 mod image;
 mod labels;
+mod sidecars;
 mod ssh;
 mod types;
 mod volume;
@@ -110,6 +111,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
                 Enter(EnterParams {
                     name,
                     shell,
+                    root,
                     work_dir,
                     container,
                 }),
@@ -124,6 +126,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
                     container.as_deref(),
                     vec![],
                     constants::DEFAULT_UID,
+                    if root { Some(constants::ROOT_USER)} else { None },
                     false,
                 )
                 .await?

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
                 Some(path) => Some(RoozCfg::from_file(&path)?),
                 None => None,
             };
-            workspace.new(&work, cfg, Some(persistence)).await?;
+            workspace.new(&work, cfg, Some(persistence), false).await?;
         }
 
         Cli {
@@ -171,10 +171,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
         }
 
         Cli {
-            command: Tmp(TmpParams { work }),
+            command: Tmp(TmpParams { work, root }),
             ..
         } => {
-            workspace.new(&work, None, None).await?;
+            workspace.new(&work, None, None, root).await?;
         }
 
         Cli {

--- a/src/sidecars.rs
+++ b/src/sidecars.rs
@@ -4,8 +4,9 @@ use bollard::network::CreateNetworkOptions;
 
 use crate::{
     backend::WorkspaceApi,
+    constants,
     labels::{self, Labels},
-    types::{RoozSidecar, RunSpec}, constants,
+    types::{RoozSidecar, RunSpec},
 };
 
 impl<'a> WorkspaceApi<'a> {

--- a/src/sidecars.rs
+++ b/src/sidecars.rs
@@ -1,0 +1,61 @@
+use std::collections::HashMap;
+
+use bollard::network::CreateNetworkOptions;
+
+use crate::{
+    backend::WorkspaceApi,
+    labels::{self, Labels},
+    types::{RoozSidecar, RunSpec}, constants,
+};
+
+impl<'a> WorkspaceApi<'a> {
+    pub async fn ensure_sidecars(
+        &self,
+        sidecars: &Option<HashMap<String, RoozSidecar>>,
+        labels: &Labels,
+        workspace_key: &str,
+        force: bool,
+        pull_image: bool,
+    ) -> Result<Option<String>, Box<dyn std::error::Error + 'static>> {
+        let labels_sidecar = Labels::new(Some(workspace_key), Some(labels::ROLE_SIDECAR));
+
+        let network = if let Some(_) = sidecars {
+            let network_options = CreateNetworkOptions::<&str> {
+                name: &workspace_key,
+                check_duplicate: true,
+                labels: labels.into(),
+
+                ..Default::default()
+            };
+
+            self.api.client.create_network(network_options).await?;
+            Some(workspace_key.as_ref())
+        } else {
+            None
+        };
+
+        if let Some(sidecars) = sidecars {
+            for (name, s) in sidecars {
+                log::debug!("Process sidecar: {}", name);
+                self.api.image.ensure(&s.image, pull_image).await?;
+                let container_name = format!("{}-{}", workspace_key, name);
+                self.api
+                    .container
+                    .create(RunSpec {
+                        container_name: &container_name,
+                        uid: constants::ROOT_UID,
+                        image: &s.image,
+                        force_recreate: force,
+                        workspace_key: &workspace_key,
+                        labels: (&labels_sidecar).into(),
+                        env: s.env.clone(),
+                        network,
+                        network_aliases: Some(vec![name.into()]),
+                        ..Default::default()
+                    })
+                    .await?;
+            }
+        }
+        Ok(network.map(|n| n.to_string()))
+    }
+}

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -41,7 +41,7 @@ chmod 400 $KEYFILE && chown -R {} /tmp/.ssh
         let run_spec = RunSpec {
             reason: "init-ssh",
             image,
-            user: Some(constants::ROOT),
+            uid: constants::ROOT_UID,
             work_dir: None,
             container_name: "rooz-init-ssh",
             workspace_key: &workspace_key,


### PR DESCRIPTION
This PR fixes the following:
* fixes #17 - now most of the settings (image, shell, caches & sidecars) can be sensibly overridden with the following priority (first - highest): cli args, local config via the `--config` switch, repo config, environment. 
* makes working with off-the-shelf containers easier by creating the desired user in the container if it doesn't exist
* thanks to the above git clone can run in an off-the-shelf image as non-root
* workspaces can now be entered with `--root` switch to make it easy to mess around.