### PR TITLE
Refac: remove the enter flag and decouple entering from creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,7 +898,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rooz"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "base64",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rooz"
-version = "0.42.0"
+version = "0.43.0"
 edition = "2021"
 
 [dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,10 +49,6 @@ pub struct WorkParams {
     pub image: Option<String>,
     #[arg(long)]
     pub pull_image: bool,
-    #[arg(long, hide = true, env = "ROOZ_SHELL")]
-    pub env_shell: Option<String>,
-    #[arg(short, long)]
-    pub shell: Option<String>,
     #[arg(long, hide = true, env = "ROOZ_USER")]
     pub env_user: Option<String>,
     #[arg(short, long)]
@@ -91,6 +87,8 @@ pub struct TmpParams {
     pub work: WorkParams,
     #[arg(short, long)]
     pub root: bool,
+    #[arg(short, long, default_value = "bash", env = "ROOZ_SHELL")]
+    pub shell: String,
 }
 
 #[derive(Parser, Debug)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,8 +37,6 @@ pub struct WorkspacePersistence {
     pub name: String,
     #[arg(short, long)]
     pub force: bool,
-    #[arg(short, long)]
-    pub enter: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -18,7 +18,7 @@ impl<'a> WorkspaceApi<'a> {
         let orig_uid = constants::DEFAULT_UID.to_string();
 
         let (workspace_key, force, enter) = match persistence {
-            Some(p) => (p.name.to_string(), p.force, p.enter),
+            Some(p) => (p.name.to_string(), p.force, false),
             None => (crate::id::random_suffix("tmp"), false, true),
         };
 
@@ -68,7 +68,6 @@ impl<'a> WorkspaceApi<'a> {
                     .with_container(Some(constants::DEFAULT_CONTAINER_NAME));
                 let work_spec = WorkSpec {
                     image,
-                    shell: &RoozCfg::shell(spec, &cli_config, &None),
                     caches: Some(RoozCfg::caches(spec, &cli_config, &None)),
                     env_vars: RoozCfg::env_vars(&cli_config, &None),
                     network: network.as_deref(),
@@ -83,7 +82,7 @@ impl<'a> WorkspaceApi<'a> {
                         &workspace_key,
                         Some(&work_spec.container_working_dir),
                         Some(&home_dir),
-                        &work_spec.shell.as_ref(),
+                        &RoozCfg::shell(spec, &cli_config, &None),
                         None,
                         volumes,
                         &orig_uid,
@@ -121,12 +120,11 @@ impl<'a> WorkspaceApi<'a> {
                             )
                             .await?;
                         let work_labels = labels
-                        .clone()
-                        .with_container(Some(constants::DEFAULT_CONTAINER_NAME));
-                        
+                            .clone()
+                            .with_container(Some(constants::DEFAULT_CONTAINER_NAME));
+
                         let work_spec = WorkSpec {
                             image,
-                            shell: &RoozCfg::shell(spec, &cli_config, &repo_config),
                             caches: Some(RoozCfg::caches(spec, &cli_config, &repo_config)),
                             env_vars: RoozCfg::env_vars(&cli_config, &repo_config),
                             container_working_dir: &git_spec.dir,
@@ -144,7 +142,7 @@ impl<'a> WorkspaceApi<'a> {
                                 &workspace_key,
                                 Some(&git_spec.dir),
                                 Some(&home_dir),
-                                &work_spec.shell,
+                                &RoozCfg::shell(spec, &cli_config, &repo_config),
                                 None,
                                 volumes,
                                 &orig_uid,

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ async fn main() -> Result<(), AnyError> {
                 Some(path) => Some(RoozCfg::from_file(&path)?),
                 None => None,
             };
-            workspace.new(&work, cfg, Some(persistence), false).await?;
+            workspace.new(&work, cfg, Some(persistence)).await?;
         }
 
         Cli {
@@ -172,10 +172,10 @@ async fn main() -> Result<(), AnyError> {
         }
 
         Cli {
-            command: Tmp(TmpParams { work, root }),
+            command: Tmp(TmpParams { work, root, shell }),
             ..
         } => {
-            workspace.new(&work, None, None, root).await?;
+            workspace.tmp(&work, root, &shell).await?;
         }
 
         Cli {

--- a/src/types.rs
+++ b/src/types.rs
@@ -122,7 +122,6 @@ impl RoozCfg {
         cli_cfg: &Option<RoozCfg>,
         repo_cfg: &Option<RoozCfg>,
     ) -> Option<HashMap<String, String>> {
-
         let mut all_env_vars = HashMap::<String, String>::new();
 
         if let Some(env) = cli_cfg.clone().map(|c| c.env).flatten() {
@@ -261,7 +260,6 @@ pub struct GitCloneSpec {
 #[derive(Clone, Debug)]
 pub struct WorkSpec<'a> {
     pub image: &'a str,
-    pub shell: &'a str,
     pub uid: &'a str,
     pub user: &'a str,
     pub container_working_dir: &'a str,
@@ -274,14 +272,13 @@ pub struct WorkSpec<'a> {
     pub privileged: bool,
     pub force_recreate: bool,
     pub network: Option<&'a str>,
-    pub env_vars: Option<HashMap<String,String>>,
+    pub env_vars: Option<HashMap<String, String>>,
 }
 
 impl Default for WorkSpec<'_> {
     fn default() -> Self {
         Self {
             image: Default::default(),
-            shell: Default::default(),
             uid: Default::default(),
             user: Default::default(),
             container_working_dir: Default::default(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -37,16 +37,11 @@ impl RoozCfg {
         }
     }
 
-    pub fn shell(
-        cli: &WorkParams,
-        cli_cfg: &Option<RoozCfg>,
-        repo_cfg: &Option<RoozCfg>,
-    ) -> String {
-        cli.shell
+    pub fn shell(cli_shell: &str, cli_cfg: &Option<RoozCfg>, repo_cfg: &Option<RoozCfg>) -> String {
+        Some(cli_shell.into())
             .clone()
             .or(cli_cfg.clone().map(|c| c.shell).flatten())
             .or(repo_cfg.clone().map(|c| c.shell).flatten())
-            .or(cli.env_shell.clone())
             .unwrap_or(constants::DEFAULT_SHELL.into())
     }
 
@@ -345,4 +340,14 @@ impl Default for RunSpec<'_> {
 pub struct WorkspaceResult {
     pub container_id: String,
     pub volumes: Vec<RoozVolume>,
+    pub workspace_key: String,
+    pub working_dir: String,
+    pub home_dir: String,
+    pub orig_uid: String,
+}
+
+pub struct EnterSpec {
+    pub workspace: WorkspaceResult,
+    pub git_spec: Option<GitCloneSpec>,
+    pub git_repo_config: Option<RoozCfg>,
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -94,7 +94,15 @@ impl<'a> WorkspaceApi<'a> {
         };
 
         match self.api.container.create(run_spec).await? {
-        ContainerResult::Created { id } => Ok(WorkspaceResult { container_id: id, volumes: volumes.iter().map(|v|v.clone()).collect::<Vec<_>>() }),
+        ContainerResult::Created { id } =>
+            Ok(
+                WorkspaceResult {
+                    workspace_key: (&spec).workspace_key.to_string(),
+                    working_dir: (&spec).container_working_dir.to_string(),
+                    home_dir,
+                    orig_uid: spec.uid.to_string(),
+                    container_id: id,
+                    volumes: volumes.iter().map(|v|v.clone()).collect::<Vec<_>>() }),
         ContainerResult::AlreadyExists { .. } => {
             Err(format!("Container already exists. Did you mean: rooz enter {}? Otherwise, use --force to recreate.", spec.workspace_key).into())
         }


### PR DESCRIPTION
Changes:
1. Remove `--enter` on `rooz new`. This was a non-documented experimental sugar flag. There is now only one way to enter non-ephemeral workspaces - via `rooz enter`.
2. Refactor `workspace.new()` - it now honors SRP by only being used to create workspaces.
3. Introduce the new `workspace.tmp()` which now creates a new ephemeral workspace and enters it.
4.  Remove `shell` and `env_shell` args from `rooz new` - this was only used when entering and is not needed for creating workspaces.