### PR TITLE
try: preserve order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,7 +1574,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rooz"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "age",
  "base64 0.21.7",
@@ -1586,6 +1586,7 @@ dependencies = [
  "env_logger",
  "futures",
  "handlebars",
+ "indexmap 2.2.6",
  "lazy_static",
  "log",
  "openssh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rooz"
-version = "0.70.0"
+version = "0.71.0"
 edition = "2021"
 
 [dependencies]
@@ -14,6 +14,7 @@ ctrlc = "3.4.4"
 env_logger = "0.10.0"
 futures = "0.3.26"
 handlebars = "5.1.2"
+indexmap = { version ="2.2.6", features = ["serde"] }
 lazy_static = "1.4.0"
 log = "0.4.20"
 openssh = "0.10.3"

--- a/src/age_utils.rs
+++ b/src/age_utils.rs
@@ -7,7 +7,7 @@ use age::x25519::{Identity, Recipient};
 use age::IdentityFileEntry::Native;
 use bollard::models::MountTypeEnum::VOLUME;
 use bollard::service::Mount;
-use std::collections::HashMap;
+use indexmap::IndexMap;
 use std::io::{Read, Write};
 use std::iter;
 
@@ -73,10 +73,8 @@ impl<'a> WorkspaceApi<'a> {
     }
 }
 
-pub fn needs_decryption(
-    env_vars: Option<HashMap<String, String>>,
-) -> Option<HashMap<String, String>> {
-    if let Some(vars) = env_vars {
+pub fn needs_decryption(vars: IndexMap<String, String>) -> Option<IndexMap<String, String>> {
+    if !vars.is_empty() {
         if vars.iter().any(|(_, v)| v.starts_with(SECRET_HEADER)) {
             Some(vars)
         } else {
@@ -96,14 +94,16 @@ pub fn encrypt(plaintext: String, recipient: Recipient) -> Result<String, AnyErr
     )?)?;
     writer.write_all(plaintext.as_bytes())?;
     writer.finish().and_then(|armor| armor.finish())?;
-    Ok(std::str::from_utf8(&encrypted)?.to_string().replace("\n", "|"))
+    Ok(std::str::from_utf8(&encrypted)?
+        .to_string()
+        .replace("\n", "|"))
 }
 
 pub fn decrypt(
     identity: &dyn age::Identity,
-    env_vars: HashMap<String, String>,
-) -> Result<HashMap<String, String>, AnyError> {
-    let mut ret = HashMap::<String, String>::new();
+    env_vars: IndexMap<String, String>,
+) -> Result<IndexMap<String, String>, AnyError> {
+    let mut ret = IndexMap::<String, String>::new();
     for (k, v) in env_vars.iter() {
         if v.starts_with(SECRET_HEADER) {
             let formatted = v.replace("|", "\n");

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -35,7 +35,7 @@ impl<'a> WorkspaceApi<'a> {
             log::debug!("Decrypting vars");
             let identity = self.read_age_identity().await?;
             let decrypted_kv = age_utils::decrypt(&identity, vars)?;
-            cfg_builder.vars = Some(decrypted_kv);
+            cfg_builder.vars = decrypted_kv;
         } else {
             log::debug!("No encrypted vars found");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -284,15 +284,15 @@ async fn main() -> Result<(), AnyError> {
             command: Encrypt(EncryptParams { config, name }),
         } => {
             let cfg = RoozCfg::from_file(&config)?;
-            if let Some(vars) = cfg.vars {
-                if vars.contains_key(&name) {
+            if !cfg.vars.is_empty() {
+                if cfg.vars.contains_key(&name) {
                     let identity = workspace.read_age_identity().await?;
                     let pub_key = identity.to_public();
-                    let encrypted = age_utils::encrypt(vars[&name].to_string(), pub_key)?;
-                    let mut new_vars = vars.clone();
+                    let encrypted = age_utils::encrypt(cfg.vars[&name].to_string(), pub_key)?;
+                    let mut new_vars = cfg.vars.clone();
                     new_vars.insert(name, encrypted);
                     RoozCfg {
-                        vars: Some(new_vars),
+                        vars: new_vars,
                         ..cfg
                     }
                     .to_file(&config)?

--- a/src/model/volume.rs
+++ b/src/model/volume.rs
@@ -141,7 +141,9 @@ impl RoozVolume {
         RoozVolume {
             path: path.into(),
             role: RoozVolumeRole::Data,
-            sharing: RoozVolumeSharing::Exclusive { key: workspace_key.into() },
+            sharing: RoozVolumeSharing::Exclusive {
+                key: workspace_key.into(),
+            },
         }
     }
 }


### PR DESCRIPTION
It works but  `indexMap::serde_seq` expects this seq of tuples syntax which is clunky. To be fixed in this PR too.

```yaml
vars:
- [ t-secret, THIS IS MY SECRET ]
- [ built-upon, "YES, YOU CAN: {{ t-secret }}" ]

env:
  SECRET: '{{ t-secret }}'
  SOMETHING: '{{ built-upon }}'

```