### PR TITLE
fix: enable referencing vars in vars below the referenced ones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1574,7 +1583,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rooz"
-version = "0.70.0"
+version = "0.71.0"
 dependencies = [
  "age",
  "base64 0.21.7",
@@ -1587,6 +1596,7 @@ dependencies = [
  "futures",
  "handlebars",
  "lazy_static",
+ "linked-hash-map",
  "log",
  "openssh",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rooz"
-version = "0.70.0"
+version = "0.71.0"
 edition = "2021"
 
 [dependencies]
@@ -15,6 +15,7 @@ env_logger = "0.10.0"
 futures = "0.3.26"
 handlebars = "5.1.2"
 lazy_static = "1.4.0"
+linked-hash-map = { version = "0.5.6", features = ["serde", "serde_impl"] }
 log = "0.4.20"
 openssh = "0.10.3"
 rand = "0.8.5"

--- a/README.md
+++ b/README.md
@@ -152,8 +152,9 @@ Rooz supports basic variable replacement/templating:
 * [handlebars](https://handlebarsjs.com/guide/) syntax is used
 * variables are declared in `vars`
 * encrypted variables are decrypted before expanding
-* referencing variables in other variables' declarations is not supported
-* otherwise handlebars can be used everywhere in the file as long as it is a valid TOML/YAML
+* handlebars can be used everywhere in the file as long as it is a valid TOML/YAML
+* var replacement works within variables themselves too. However, only if the var usage is 
+below the var definition (in the document order).
 
 ```yaml
 

--- a/src/api/sidecar.rs
+++ b/src/api/sidecar.rs
@@ -88,7 +88,11 @@ impl<'a> WorkspaceApi<'a> {
                     force_recreate: force,
                     workspace_key: &workspace_key,
                     labels: (&labels).into(),
-                    env: s.env.clone(),
+                    env: s.env.clone().map(|x| {
+                        x.iter()
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect::<HashMap<_, _>>()
+                    }),
                     network,
                     network_aliases: Some(vec![name.into()]),
                     command: s

--- a/src/model/volume.rs
+++ b/src/model/volume.rs
@@ -141,7 +141,9 @@ impl RoozVolume {
         RoozVolume {
             path: path.into(),
             role: RoozVolumeRole::Data,
-            sharing: RoozVolumeSharing::Exclusive { key: workspace_key.into() },
+            sharing: RoozVolumeSharing::Exclusive {
+                key: workspace_key.into(),
+            },
         }
     }
 }


### PR DESCRIPTION
fix: maintain order on vars, env, sidecars, sidecars.env

Using LinkedHashMap to preserve ser/de order.
