### PR TITLE
Support CLI configs from another repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,7 +1621,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rooz"
-version = "0.81.0"
+version = "0.82.0"
 dependencies = [
  "age",
  "base64 0.21.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rooz"
-version = "0.81.0"
+version = "0.82.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ rooz new myworkspace
 ### Create a workspace from a git repo
 
 ```sh
-rooz new -g git@github.com:your/repo.git myworkspace2
+rooz new -g git@github.com:your/repo myworkspace2
 ```
 ### 
 
@@ -102,6 +102,7 @@ Most of the settings can be configured via:
 * environment variables
 * a config file in the cloned repository (if any)  (`.rooz.toml`, `rooz.yaml`)
 * a config file specified via `--config` (on `rooz new`) (`toml/yaml`)
+  :information_source: it can be a local file path or a remote git file like: `git@github.com/my/configs//path/in/repo/config.rooz.yaml`
 * cmd-line parameters
 
 The configuration file provides the most options: [example](examples/dotnet-nats.rooz.toml)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -166,7 +166,7 @@ pub struct StopParams {
 }
 
 #[derive(Parser, Debug)]
-#[command(about = "Describes a workspace")]
+#[command(about = "Describes a workspace", alias = "desc")]
 pub struct DescribeParams {
     #[arg()]
     pub name: String,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,7 +64,7 @@ pub struct WorkspacePersistence {
         short,
         long,
         conflicts_with = "replace",
-        requires = "config",
+        requires = "config_path",
         help = "Recreates workspace containers with the given configuration"
     )]
     pub apply: bool,
@@ -108,9 +108,10 @@ pub struct NewParams {
     pub work: WorkParams,
     #[arg(
         long,
-        help = "Configures the new workspace from a config file given by the path."
+        help = "Configures the new workspace from a config file given by the path.",
+        alias = "config"
     )]
-    pub config: Option<String>,
+    pub config_path: Option<String>,
 }
 
 #[derive(Parser, Debug)]
@@ -175,8 +176,8 @@ pub struct DescribeParams {
 #[derive(Parser, Debug)]
 #[command(about = "Encrypts a variable in the vars section of the provided config file")]
 pub struct EncryptParams {
-    #[arg(long, short, help = "Target config file")]
-    pub config: String,
+    #[arg(long, short, help = "Target config file", alias = "config")]
+    pub config_file_path: String,
     #[arg(help = "Target variable name")]
     pub name: String,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,15 +107,13 @@ async fn main() -> Result<(), AnyError> {
                 New(NewParams {
                     work,
                     persistence,
-                    config,
+                    config_path,
                 }),
             ..
         } => {
-            let cfg = match config {
-                Some(path) => Some(RoozCfg::from_file(&path)?),
-                None => None,
-            };
-            workspace.new(&work, cfg, Some(persistence.clone())).await?;
+            workspace
+                .new(&work, config_path, Some(persistence.clone()))
+                .await?;
             println!(
                 "\nThe workspace is ready. Run 'rooz enter {}' to enter.",
                 persistence.name
@@ -212,9 +210,13 @@ async fn main() -> Result<(), AnyError> {
         }
 
         Cli {
-            command: Encrypt(EncryptParams { config, name }),
+            command:
+                Encrypt(EncryptParams {
+                    config_file_path,
+                    name,
+                }),
         } => {
-            let cfg = RoozCfg::from_file(&config)?;
+            let cfg = RoozCfg::from_file(&config_file_path)?;
             if let Some(vars) = cfg.vars {
                 if vars.contains_key(&name) {
                     let identity = workspace.read_age_identity().await?;
@@ -226,10 +228,10 @@ async fn main() -> Result<(), AnyError> {
                         vars: Some(new_vars),
                         ..cfg
                     }
-                    .to_file(&config)?
+                    .to_file(&config_file_path)?
                 }
             } else {
-                println!("Var {} not found in {}", &name, &config)
+                println!("Var {} not found in {}", &name, &config_file_path)
             }
         }
 

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -6,6 +6,31 @@ use std::{collections::HashMap, ffi::OsStr, fs, path::Path};
 
 use super::types::AnyError;
 
+#[derive(Debug, Clone)]
+pub enum ConfigPath {
+    File { path: String },
+    Git { url: String, file_path: String },
+}
+
+impl<'a> ConfigPath {
+    pub fn from_str(value: &'a str) -> Result<Self, AnyError> {
+        if value.starts_with("git@") || value.starts_with("ssh://") {
+            let chunks = value.split("//").collect::<Vec<_>>();
+            match chunks.as_slice() {
+                &[url, file_path] => Ok(Self::Git {
+                    url: url.to_string(),
+                    file_path: file_path.to_string(),
+                }),
+                _ => Err(format!("Invalid repo URL {}", value).into()),
+            }
+        } else {
+            Ok(Self::File {
+                path: value.to_string(),
+            })
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum FileFormat {
     Toml,


### PR DESCRIPTION
At present `rooz new --config ..` only supports local files. Now it'll also support files in remote repos like `git@github.com:remote/repo//path/in/repo/my.rooz.yaml`. It uses `//` as a repo path separator.