### PR TITLE
Bug fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,7 +1621,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rooz"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "age",
  "base64 0.21.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rooz"
-version = "0.84.0"
+version = "0.85.0"
 edition = "2021"
 
 [dependencies]

--- a/src/api/container.rs
+++ b/src/api/container.rs
@@ -83,7 +83,8 @@ impl<'a> ContainerApi<'a> {
             }
         }
 
-        match self.client
+        match self
+            .client
             .remove_container(
                 &container_id,
                 Some(RemoveContainerOptions {
@@ -91,17 +92,24 @@ impl<'a> ContainerApi<'a> {
                     ..Default::default()
                 }),
             )
-            .await {
-                Ok(_) =>  {
-                    log::debug!("Removed container: {}{}", &container_id, &force_display);
-                    Ok(())
-                },
-                Err(Error::DockerResponseServerError { status_code:404, .. }) => {
-                    log::debug!("No such container. Skipping: {}{}", &container_id, &force_display);
-                    Ok(())
-                },
-                Err(e) => panic!("{}", e),
-            }    
+            .await
+        {
+            Ok(_) => {
+                log::debug!("Removed container: {}{}", &container_id, &force_display);
+                Ok(())
+            }
+            Err(Error::DockerResponseServerError {
+                status_code: 404, ..
+            }) => {
+                log::debug!(
+                    "No such container. Skipping: {}{}",
+                    &container_id,
+                    &force_display
+                );
+                Ok(())
+            }
+            Err(e) => panic!("{}", e),
+        }
     }
 
     pub async fn kill(&self, container_id: &str) -> Result<(), AnyError> {

--- a/src/api/container.rs
+++ b/src/api/container.rs
@@ -83,7 +83,7 @@ impl<'a> ContainerApi<'a> {
             }
         }
 
-        self.client
+        match self.client
             .remove_container(
                 &container_id,
                 Some(RemoveContainerOptions {
@@ -91,10 +91,17 @@ impl<'a> ContainerApi<'a> {
                     ..Default::default()
                 }),
             )
-            .await?;
-
-        log::debug!("Remove container: {}{}", &container_id, &force_display);
-        Ok(())
+            .await {
+                Ok(_) =>  {
+                    log::debug!("Removed container: {}{}", &container_id, &force_display);
+                    Ok(())
+                },
+                Err(Error::DockerResponseServerError { status_code:404, .. }) => {
+                    log::debug!("No such container. Skipping: {}{}", &container_id, &force_display);
+                    Ok(())
+                },
+                Err(e) => panic!("{}", e),
+            }    
     }
 
     pub async fn kill(&self, container_id: &str) -> Result<(), AnyError> {

--- a/src/api/exec.rs
+++ b/src/api/exec.rs
@@ -63,18 +63,19 @@ impl<'a> ExecApi<'a> {
                         }
                     });
 
-                    if interactive {
-                        self.client
-                            .resize_exec(
-                                exec_id,
-                                ResizeExecOptions {
-                                    height: tty_size.1,
-                                    width: tty_size.0,
-                                },
-                            )
-                            .await?;
-                    };
-
+                    if let Some(true) = exec_state.running {
+                        if interactive {
+                            self.client
+                                .resize_exec(
+                                    exec_id,
+                                    ResizeExecOptions {
+                                        height: tty_size.1,
+                                        width: tty_size.0,
+                                    },
+                                )
+                                .await?;
+                        };
+                    }
                     // set stdout in raw mode so we can do tty stuff
                     let stdout = stdout();
                     let mut stdout = stdout.lock().into_raw_mode()?;
@@ -167,6 +168,7 @@ impl<'a> ExecApi<'a> {
         let exec_id = self
             .create_exec(reason, container_id, working_dir, user, cmd)
             .await?;
+
         self.start_tty(&exec_id, interactive).await
     }
 


### PR DESCRIPTION
This PR fixes the following issues:
* when applying config to an existing workspace (`rooz new --apply --config ...`) the volumes already exist and git clone exec terminates instantly. As the exec is not longer running resizing the exec no longer makes sense (no chance for interactivity) and it crashes the process. Checking if exec is running reduces the chance of such a failure.
* in the same mode when removing containers it may happen that there are workspace containers that are terminating. Hence remove containers now will ignore and log the 404 if a container showes up on the candidate list but terminates before the remove call is performed.