### PR TITLE
add: store config to a volume side-by-side with labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags",
 ]
@@ -1986,7 +1986,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rooz"
-version = "0.112.0"
+version = "0.113.0"
 dependencies = [
  "age",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rooz"
-version = "0.112.0"
+version = "0.113.0"
 edition = "2021"
 
 [dependencies]

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -1,8 +1,12 @@
 use std::io;
 
 use crate::{
-    config::config::{FileFormat, RoozCfg},
-    model::types::AnyError,
+    config::config::{ConfigType, FileFormat, RoozCfg},
+    constants,
+    model::{
+        types::AnyError,
+        volume::RoozVolume,
+    },
 };
 
 use age::x25519::Identity;
@@ -11,6 +15,21 @@ use colored::Colorize;
 use super::ConfigApi;
 
 impl<'a> ConfigApi<'a> {
+    pub async fn store(
+        &self,
+        workspace_key: &str,
+        config_type: &ConfigType,
+        data: &str,
+    ) -> Result<(), AnyError> {
+        let config_vol =
+            RoozVolume::sidecar_data(workspace_key, config_type.file_path(), Some(data.to_string()));
+        self.api
+            .volume
+            .ensure_files(vec![config_vol], constants::ROOT_UID)
+            .await?;
+        Ok(())
+    }
+
     fn edit_error(&self, message: &str) -> () {
         eprintln!("{}", "Error: Invalid configuration".bold().red());
         eprintln!("{}", message.red());

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -89,7 +89,7 @@ impl<'a> WorkspaceApi<'a> {
                     pull_image: if no_pull || interactive { false } else { true },
                     ..Default::default()
                 },
-                Some(ConfigSource::Body {
+                Some(ConfigSource::Update {
                     value: config_to_apply,
                     origin: config_source.to_string(),
                     format,

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -8,7 +8,7 @@ use std::{collections::HashMap, ffi::OsStr, fs, path::Path};
 
 #[derive(Debug, Clone)]
 pub enum ConfigSource {
-    Body {
+    Update {
         value: RoozCfg,
         origin: String,
         format: FileFormat,
@@ -46,6 +46,23 @@ impl<'a> ConfigPath {
         match self {
             ConfigPath::File { path } => path.to_string(),
             ConfigPath::Git { url, file_path } => format!("{}//{}", url, file_path),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ConfigType {
+    Origin,
+    Body,
+    Runtime,
+}
+
+impl ConfigType {
+    pub fn file_path(&self) -> &str {
+        match self {
+            ConfigType::Origin => "/etc/rooz/origin.config",
+            ConfigType::Body => "/etc/rooz/workspace.config",
+            ConfigType::Runtime => "/etc/rooz/runtime.config",
         }
     }
 }


### PR DESCRIPTION
Part 1 of migrating config storage from labels to a volume.