### PR TITLE
fix: if uid exists in /etc/passwd with different user - replace; fix: if exists do not add again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1986,7 +1986,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rooz"
-version = "0.113.0"
+version = "0.114.0"
 dependencies = [
  "age",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rooz"
-version = "0.113.0"
+version = "0.114.0"
 edition = "2021"
 
 [dependencies]

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -3,10 +3,7 @@ use std::io;
 use crate::{
     config::config::{ConfigType, FileFormat, RoozCfg},
     constants,
-    model::{
-        types::AnyError,
-        volume::RoozVolume,
-    },
+    model::{types::AnyError, volume::RoozVolume},
 };
 
 use age::x25519::Identity;
@@ -21,8 +18,11 @@ impl<'a> ConfigApi<'a> {
         config_type: &ConfigType,
         data: &str,
     ) -> Result<(), AnyError> {
-        let config_vol =
-            RoozVolume::sidecar_data(workspace_key, config_type.file_path(), Some(data.to_string()));
+        let config_vol = RoozVolume::config_data(
+            workspace_key,
+            config_type.file_path(),
+            Some(data.to_string()),
+        );
         self.api
             .volume
             .ensure_files(vec![config_vol], constants::ROOT_UID)

--- a/src/api/exec.rs
+++ b/src/api/exec.rs
@@ -264,8 +264,9 @@ impl<'a> ExecApi<'a> {
     pub async fn ensure_user(&self, container_id: &str) -> Result<(), AnyError> {
         let ensure_user_cmd = container::inject(
             format!(
-                    r#"whoami > /dev/null 2>&1 && [ "$(whoami)" = "$ROOZ_META_USER" ] || \
-                       echo "$ROOZ_META_USER:x:$ROOZ_META_UID:$ROOZ_META_UID:$ROOZ_META_USER:$ROOZ_META_HOME:/bin/sh" >> /etc/passwd"#,
+                    r#"grep -q "^$ROOZ_META_USER:x:$ROOZ_META_UID" /etc/passwd && exit 0
+                       sed -i "/:x:${{ROOZ_META_UID}}/d" /etc/passwd && \
+                       echo "$ROOZ_META_USER:x:$ROOZ_META_UID:$ROOZ_META_UID:$ROOZ_META_USER:$ROOZ_META_HOME:/bin/sh" >> /etc/passwd"#, 
             )
             .as_ref(),
             "make_user.sh",

--- a/src/api/sidecar.rs
+++ b/src/api/sidecar.rs
@@ -65,14 +65,10 @@ impl<'a> WorkspaceApi<'a> {
                     .iter()
                     .map(|mount| match mount {
                         crate::config::config::SidecarMount::Empty(mount) => {
-                            RoozVolume::sidecar_data(workspace_key, mount, None)
+                            RoozVolume::config_data(workspace_key, mount, None)
                         }
                         crate::config::config::SidecarMount::Content { mount, content } => {
-                            RoozVolume::sidecar_data(
-                                workspace_key,
-                                mount,
-                                Some(content.to_string()),
-                            )
+                            RoozVolume::config_data(workspace_key, mount, Some(content.to_string()))
                         }
                     })
                     .collect::<Vec<_>>()

--- a/src/model/volume.rs
+++ b/src/model/volume.rs
@@ -149,7 +149,7 @@ impl RoozVolume {
         }
     }
 
-    pub fn sidecar_data(workspace_key: &str, path: &str, data: Option<String>) -> RoozVolume {
+    pub fn config_data(workspace_key: &str, path: &str, data: Option<String>) -> RoozVolume {
         match data {
             Some(data) => RoozVolume {
                 path: match Path::new(path).parent() {


### PR DESCRIPTION
The fix improves usage of non-curated container images.


Also:

chore: rename sidecar_data to config_data
chore: fmt